### PR TITLE
Mainzelliste caching

### DIFF
--- a/mvc/pom.xml
+++ b/mvc/pom.xml
@@ -40,7 +40,7 @@
 		<dependency>
 			<groupId>com.hazelcast</groupId>
 			<artifactId>hazelcast</artifactId>
-			<version>3.9-EA</version>
+			<version>3.12.10</version>
 		</dependency>
 
 		<dependency>

--- a/mvc/src/main/java/org/karnak/data/AppConfig.java
+++ b/mvc/src/main/java/org/karnak/data/AppConfig.java
@@ -4,7 +4,6 @@ import org.karnak.data.profile.ProfilePersistence;
 import org.karnak.profilepipe.Profiles;
 import org.karnak.profilepipe.profilebody.ProfilePipeBody;
 import org.karnak.standard.ConfidentialityProfiles;
-import org.karnak.profilepipe.utils.HMAC;
 import org.karnak.ui.extid.Patient;
 import org.karnak.ui.profile.ProfilePipeService;
 import org.karnak.ui.profile.ProfilePipeServiceImpl;
@@ -105,6 +104,16 @@ public class AppConfig {
         final MutableConfiguration<String, Patient> config = new MutableConfiguration<>();
         config.setExpiryPolicyFactory(expiryPolicyFactory);
         return cacheManager.createCache("simpleCache", config);
+    }
+
+    @Bean("CacheMainzelliste")
+    public Cache<String, Patient> getMainzellisteCache(){
+        final CacheManager cacheManager = Caching.getCachingProvider().getCacheManager();
+        final Duration duration = new Duration(TimeUnit.MINUTES, 15L);
+        final Factory expiryPolicyFactory = CreatedExpiryPolicy.factoryOf(duration);
+        final MutableConfiguration<String, Patient> config = new MutableConfiguration<>();
+        config.setExpiryPolicyFactory(expiryPolicyFactory);
+        return cacheManager.createCache("mainzelliste", config);
     }
 
     // https://stackoverflow.com/questions/27405713/running-code-after-spring-boot-starts

--- a/mvc/src/main/java/org/karnak/profilepipe/Profiles.java
+++ b/mvc/src/main/java/org/karnak/profilepipe/Profiles.java
@@ -4,8 +4,6 @@ import java.awt.Color;
 import java.awt.Shape;
 import java.io.IOException;
 import java.math.BigInteger;
-import java.time.LocalDate;
-import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -20,7 +18,6 @@ import org.dcm4che6.data.Tag;
 import org.dcm4che6.data.VR;
 import org.dcm4che6.img.op.MaskArea;
 import org.dcm4che6.img.util.DicomObjectUtil;
-import org.dcm4che6.util.DateTimeUtils;
 import org.dcm4che6.util.TagUtils;
 import org.karnak.api.PseudonymApi;
 import org.karnak.api.rqbody.Fields;
@@ -41,7 +38,7 @@ import org.karnak.expression.ExprAction;
 import org.karnak.profilepipe.utils.HMAC;
 import org.karnak.profilepipe.utils.PatientMetadata;
 import org.karnak.ui.extid.Patient;
-import org.karnak.util.CachingUtil;
+import org.karnak.util.PatientCachingUtil;
 import org.karnak.profilepipe.utils.HashContext;
 import org.karnak.util.SpecialCharacter;
 import org.slf4j.Logger;
@@ -153,7 +150,7 @@ public class Profiles {
             }
         } else {
             PatientMetadata patientMetadata = new PatientMetadata(dcm);
-            pseudonym = CachingUtil.getPseudonym(patientMetadata, cache);
+            pseudonym = PatientCachingUtil.getPseudonym(patientMetadata, cache);
 
             if(pseudonym == null){
                 final String issuerOfPatientID = dcm.getString(Tag.IssuerOfPatientID)

--- a/mvc/src/main/java/org/karnak/profilepipe/Pseudonym.java
+++ b/mvc/src/main/java/org/karnak/profilepipe/Pseudonym.java
@@ -1,0 +1,104 @@
+package org.karnak.profilepipe;
+
+import org.dcm4che6.data.DicomObject;
+import org.dcm4che6.data.Tag;
+import org.dcm4che6.util.TagUtils;
+import org.karnak.api.PseudonymApi;
+import org.karnak.api.rqbody.Fields;
+import org.karnak.data.AppConfig;
+import org.karnak.data.gateway.Destination;
+import org.karnak.data.gateway.IdTypes;
+import org.karnak.profilepipe.utils.PatientMetadata;
+import org.karnak.ui.extid.Patient;
+import org.karnak.util.PatientCachingUtil;
+import org.karnak.util.SpecialCharacter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.cache.Cache;
+import java.io.IOException;
+
+public class Pseudonym {
+    private Cache<String, Patient> cache;
+    private Cache<String, Patient> mainzellisteCache;
+
+    private final Logger LOGGER = LoggerFactory.getLogger(Pseudonym.class);
+
+    public Pseudonym() {
+        cache = AppConfig.getInstance().getCache();
+        mainzellisteCache = AppConfig.getInstance().getMainzellisteCache();
+    }
+
+    public String generatePseudonym(Destination destination, DicomObject dcm, String defaultIsserOfPatientID) {
+        String pseudonym;
+        if (destination.getSavePseudonym() != null && destination.getSavePseudonym() == false) {
+            pseudonym = getExtIDInDicom(dcm, destination);
+            if (pseudonym == null) {
+                throw new IllegalStateException("Cannot get a pseudonym in a DICOM tag");
+            }
+            return pseudonym;
+        }
+        PatientMetadata patientMetadata = new PatientMetadata(dcm);
+        pseudonym = PatientCachingUtil.getPseudonym(patientMetadata, cache);
+
+        if (pseudonym == null) {
+            final String issuerOfPatientID = dcm.getString(Tag.IssuerOfPatientID)
+                    .orElse(defaultIsserOfPatientID);
+            patientMetadata.setIssuerOfPatientID(issuerOfPatientID);
+            try {
+                pseudonym = getMainzellistePseudonym(patientMetadata, getExtIDInDicom(dcm, destination),
+                        destination.getIdTypes());
+            } catch (Exception e) {
+                LOGGER.error("Cannot get a pseudonym with Mainzelliste API {}", e);
+                throw new IllegalStateException("Cannot get a pseudonym in cache or with Mainzelliste API");
+            }
+        }
+        return pseudonym;
+    }
+
+    private String getExtIDInDicom(DicomObject dcm, Destination destination) {
+        if (destination.getIdTypes().equals(IdTypes.ADD_EXTID)) {
+            String cleanTag = destination.getTag().replaceAll("[(),]", "").toUpperCase();
+            final String tagValue = dcm.getString(TagUtils.intFromHexString(cleanTag)).orElse(null);
+            if (tagValue != null && destination.getDelimiter() != null && destination.getPosition() != null) {
+                String delimiterSpec = SpecialCharacter.escapeSpecialRegexChars(destination.getDelimiter());
+                try {
+                    return tagValue.split(delimiterSpec)[destination.getPosition()];
+                } catch (ArrayIndexOutOfBoundsException e) {
+                    LOGGER.error("Can not split the external pseudonym", e);
+                    return null;
+                }
+            } else if (tagValue != null) {
+                return tagValue;
+            }
+        }
+        return null;
+    }
+
+    public String getMainzellistePseudonym(PatientMetadata patientMetadata, String externalPseudonym, IdTypes idTypes) throws IOException, InterruptedException {
+        final String cachedPseudonym = PatientCachingUtil.getPseudonym(patientMetadata, mainzellisteCache);
+        if (cachedPseudonym != null) {
+            cachingMainzellistePseudonym(cachedPseudonym, patientMetadata);
+            return cachedPseudonym;
+        }
+
+        PseudonymApi pseudonymApi = new PseudonymApi(externalPseudonym);
+        final Fields newPatientFields = patientMetadata.generateMainzellisteFields();
+
+        String pseudonym = pseudonymApi.createPatient(newPatientFields, idTypes);
+        cachingMainzellistePseudonym(pseudonym, patientMetadata);
+        return pseudonym;
+    }
+
+    private void cachingMainzellistePseudonym(String pseudonym, PatientMetadata patientMetadata) {
+        final Patient patient = new Patient(pseudonym,
+                patientMetadata.getPatientID(),
+                patientMetadata.getPatientFirstName(),
+                patientMetadata.getPatientLastName(),
+                patientMetadata.getLocalDatePatientBirthDate(),
+                patientMetadata.getPatientSex(),
+                patientMetadata.getIssuerOfPatientID());
+        mainzellisteCache.remove(PatientCachingUtil.generateKey(patientMetadata));
+        mainzellisteCache.put(PatientCachingUtil.generateKey(patientMetadata), patient);
+    }
+}

--- a/mvc/src/main/java/org/karnak/profilepipe/utils/PatientMetadata.java
+++ b/mvc/src/main/java/org/karnak/profilepipe/utils/PatientMetadata.java
@@ -20,8 +20,8 @@ public class PatientMetadata {
     private final String PATIENT_SEX_OTHER = "0";
 
     public PatientMetadata(DicomObject dcm) {
-        patientID = dcm.getString(Tag.PatientID).orElse(null);
-        patientName = dcm.getString(Tag.PatientName).orElse(null);
+        patientID = dcm.getString(Tag.PatientID).orElse("");
+        patientName = dcm.getString(Tag.PatientName).orElse("");
         patientBirthDate = setPatientBirthDate(dcm.getString(Tag.PatientBirthDate).orElse(""));
         issuerOfPatientID = dcm.getString(Tag.IssuerOfPatientID).orElse("");
         patientSex = setPatientSex(dcm.getString(Tag.PatientSex).orElse("O"));
@@ -37,7 +37,7 @@ public class PatientMetadata {
     private String setPatientBirthDate(String rawPatientBirthDate) {
         if (rawPatientBirthDate != null && !rawPatientBirthDate.equals("")) {
             final LocalDate patientBirthDateLocalDate = DateTimeUtils.parseDA(rawPatientBirthDate);
-            return patientBirthDateLocalDate.format(DateTimeFormatter.ofPattern("YYYYMMdd"));
+            return DateTimeUtils.formatDA(patientBirthDateLocalDate);
         }
         return "";
     }
@@ -87,13 +87,8 @@ public class PatientMetadata {
 
     public boolean compareCachedPatient(Patient patient) {
         if (patient != null) {
-            LocalDate localDatePatientBirthDate = patient.getPatientBirthDate();
-            String patientBirthDateFormat = "";
-            if (localDatePatientBirthDate != null) {
-                patientBirthDateFormat = localDatePatientBirthDate.format(formatter);
-            }
             return (patient.getPatientId().equals(patientID) && patient.getPatientNameDicomFormat().equals(patientName) &&
-                    patientBirthDateFormat.equals(patientBirthDate) &&
+                    patient.getFormatPatientBirthDate().equals(patientBirthDate) &&
                     patient.getIssuerOfPatientId().equals(issuerOfPatientID) &&
                     patient.getPatientSex().equals(patientSex));
         }

--- a/mvc/src/main/java/org/karnak/ui/extid/AddNewPatientForm.java
+++ b/mvc/src/main/java/org/karnak/ui/extid/AddNewPatientForm.java
@@ -19,7 +19,7 @@ import org.karnak.api.rqbody.Fields;
 import org.karnak.data.AppConfig;
 import org.karnak.data.gateway.IdTypes;
 import org.karnak.ui.component.ConfirmDialog;
-import org.karnak.util.CachingUtil;
+import org.karnak.util.PatientCachingUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -207,7 +207,7 @@ public class AddNewPatientForm extends VerticalLayout {
             } else {
                 dataProvider.getItems().add(newPatient);
                 dataProvider.refreshAll();
-                cache.put(CachingUtil.generateKey(newPatient), newPatient);
+                cache.put(PatientCachingUtil.generateKey(newPatient), newPatient);
                 binder.readBean(null);
             }
         }

--- a/mvc/src/main/java/org/karnak/ui/extid/ExternalIDGrid.java
+++ b/mvc/src/main/java/org/karnak/ui/extid/ExternalIDGrid.java
@@ -13,7 +13,7 @@ import com.vaadin.flow.data.provider.ListDataProvider;
 import com.vaadin.flow.data.validator.StringLengthValidator;
 import org.apache.commons.lang3.StringUtils;
 import org.karnak.data.AppConfig;
-import org.karnak.util.CachingUtil;
+import org.karnak.util.PatientCachingUtil;
 
 import javax.cache.Cache;
 import java.util.*;
@@ -90,8 +90,8 @@ public class ExternalIDGrid extends Grid<Patient> {
                     patientBirthDateField.getValue(),
                     patientSexField.getValue(),
                     issuerOfPatientIdField.getValue());
-            cache.remove(CachingUtil.generateKey(editor.getItem())); //old extid
-            cache.put(CachingUtil.generateKey(patientEdit), patientEdit); //new extid
+            cache.remove(PatientCachingUtil.generateKey(editor.getItem())); //old extid
+            cache.put(PatientCachingUtil.generateKey(patientEdit), patientEdit); //new extid
             editor.save();
         });
         saveEditPatientButton.addThemeVariants(ButtonVariant.LUMO_PRIMARY);
@@ -148,7 +148,7 @@ public class ExternalIDGrid extends Grid<Patient> {
             deletePatientButton.addClickListener( e -> {
                 patientList.remove(patient);
                 getDataProvider().refreshAll();
-                cache.remove(CachingUtil.generateKey(patient));
+                cache.remove(PatientCachingUtil.generateKey(patient));
             });
             return deletePatientButton;
         });

--- a/mvc/src/main/java/org/karnak/ui/extid/Patient.java
+++ b/mvc/src/main/java/org/karnak/ui/extid/Patient.java
@@ -1,5 +1,7 @@
 package org.karnak.ui.extid;
 
+import org.dcm4che6.util.DateTimeUtils;
+
 import java.io.Serializable;
 import java.time.LocalDate;
 
@@ -51,6 +53,13 @@ public class Patient implements Serializable {
 
     public void setPatientBirthDate(LocalDate patientBirthDate) {
         this.patientBirthDate = patientBirthDate;
+    }
+
+    public String getFormatPatientBirthDate() {
+        if (patientBirthDate != null) {
+            return DateTimeUtils.formatDA(patientBirthDate);
+        }
+        return "";
     }
 
     public String getPatientSex() {

--- a/mvc/src/main/java/org/karnak/ui/extid/Patient.java
+++ b/mvc/src/main/java/org/karnak/ui/extid/Patient.java
@@ -70,7 +70,7 @@ public class Patient implements Serializable {
     }
 
     public String getPatientNameDicomFormat(){
-        return String.format("%s^%s", patientLastName, patientFirstName);
+        return patientFirstName == null ? patientLastName : String.format("%s^%s", patientLastName, patientFirstName);
     }
 
     public Patient(String extid, String patientId, String patientFirstName, String patientLastName, LocalDate patientBirthDate, String patientSex, String issuerOfPatientId)

--- a/mvc/src/main/java/org/karnak/util/PatientCachingUtil.java
+++ b/mvc/src/main/java/org/karnak/util/PatientCachingUtil.java
@@ -5,8 +5,8 @@ import org.karnak.ui.extid.Patient;
 
 import javax.cache.Cache;
 
-public class CachingUtil {
-    public CachingUtil() {
+public class PatientCachingUtil {
+    public PatientCachingUtil() {
     }
 
     public static String getPseudonym(PatientMetadata patientMetadata, Cache<String, Patient> cache) {

--- a/mvc/src/main/java/org/karnak/util/PatientCachingUtil.java
+++ b/mvc/src/main/java/org/karnak/util/PatientCachingUtil.java
@@ -21,7 +21,7 @@ public class PatientCachingUtil {
     }
 
     public static String generateKey(String PatientID, String PatientName, String IssuerOfPatientID) {
-        return PatientID.concat(PatientName);
+        return PatientID.concat(PatientName).concat(IssuerOfPatientID);
     }
 
     public static String generateKey(Patient patient) {


### PR DESCRIPTION
Was done:
Upgrade Hazelcast
Fix PatientName dicom format
Create pseudonym class, based from the Profile code, to manage the pseudonym from Mainzelliste and from the cache
The mainzelliste pseudonym is keept in the cache 15 minutes

To test:
Send DICOM data and verify that the cache is used instead of Mainzelliste API after the pseudonym creation.

Fixed #53 
