### PR TITLE
ExternalID : Delete selected and delete all buttons

### DIFF
--- a/src/main/java/org/karnak/frontend/extid/ExternalIDGrid.java
+++ b/src/main/java/org/karnak/frontend/extid/ExternalIDGrid.java
@@ -9,6 +9,7 @@
  */
 package org.karnak.frontend.extid;
 
+import com.vaadin.flow.component.Text;
 import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.button.ButtonVariant;
 import com.vaadin.flow.component.grid.Grid;
@@ -32,6 +33,7 @@ import org.karnak.backend.cache.PatientClient;
 import org.karnak.backend.config.AppConfig;
 import org.karnak.backend.data.entity.ProjectEntity;
 import org.karnak.backend.util.PatientClientUtil;
+import org.karnak.frontend.component.WarningConfirmDialog;
 import org.vaadin.klaudeta.PaginatedGrid;
 
 public class ExternalIDGrid extends PaginatedGrid<Patient, PatientFilter> {
@@ -53,6 +55,10 @@ public class ExternalIDGrid extends PaginatedGrid<Patient, PatientFilter> {
 	private transient ProjectEntity projectEntity;
 
 	private Button deletePatientButton;
+
+	private Button deleteAllSelectedPatientsButton;
+
+	private List<Patient> selectedPatients;
 
 	private Button saveEditPatientButton;
 
@@ -106,6 +112,8 @@ public class ExternalIDGrid extends PaginatedGrid<Patient, PatientFilter> {
 		this.externalIDCache = AppConfig.getInstance().getExternalIDCache();
 		// TODO: to use instead of the current multiple filters..: cf TELIMA-257
 		this.patientFilter = new PatientFilter();
+
+		setSelectionMode(Grid.SelectionMode.MULTI);
 
 		setPageSize(10);
 		setPaginatorSize(2);
@@ -180,6 +188,28 @@ public class ExternalIDGrid extends PaginatedGrid<Patient, PatientFilter> {
 		patientLastNameColumn.setEditorComponent(patientLastNameField);
 		issuerOfPatientIDColumn.setEditorComponent(issuerOfPatientIdField);
 
+		deleteAllSelectedPatientsButton = new Button("Delete selected patients");
+		deleteAllSelectedPatientsButton.addThemeVariants(ButtonVariant.LUMO_ERROR, ButtonVariant.LUMO_PRIMARY);
+		deleteAllSelectedPatientsButton.addClickListener(e -> {
+			if (selectedPatients != null && !selectedPatients.isEmpty()) {
+				Div dialogContent = new Div();
+				dialogContent.add(new Text("Do you confirm the deletion of the " + selectedPatients.size() + " selected patients ?"));
+				WarningConfirmDialog dialog = new WarningConfirmDialog(dialogContent);
+				dialog.addConfirmationListener(componentEvent -> {
+					for (Patient p : selectedPatients) {
+						externalIDCache.remove(PatientClientUtil.generateKey(p, projectEntity.getId()));
+					}
+					readAllCacheValue();
+				});
+				dialog.open();
+			}
+		});
+
+		addSelectionListener(selection -> {
+			selectedPatients = new ArrayList<>();
+			selectedPatients = selection.getAllSelectedItems().stream().toList();
+		});
+
 		deleteColumn = addComponentColumn(patient -> {
 			deletePatientButton = new Button("Delete");
 			deletePatientButton.addThemeVariants(ButtonVariant.LUMO_ERROR, ButtonVariant.LUMO_PRIMARY);
@@ -188,10 +218,11 @@ public class ExternalIDGrid extends PaginatedGrid<Patient, PatientFilter> {
 				readAllCacheValue();
 			});
 			return deletePatientButton;
-		});
+		}).setHeader(deleteAllSelectedPatientsButton);
 
 		saveEditPatientButton = new Button(LABEL_SAVE);
 		cancelEditPatientButton = new Button(LABEL_CANCEL);
+		cancelEditPatientButton.getStyle().set("margin-left", "10px");
 
 		Div buttons = new Div(saveEditPatientButton, cancelEditPatientButton);
 		editorColumn.setEditorComponent(buttons);
@@ -276,7 +307,7 @@ public class ExternalIDGrid extends PaginatedGrid<Patient, PatientFilter> {
 			Collection<Patient> patients = externalIDCache.getAll();
 			patientsListInCache = new ArrayList<>();
 			for (Iterator<Patient> iterator = patients.iterator(); iterator.hasNext();) {
-				final Patient patient = (Patient) iterator.next();
+				final Patient patient = iterator.next();
 				if (projectEntity != null && patient.getProjectID() != null
 						&& patient.getProjectID().equals(projectEntity.getId())) {
 					patientsListInCache.add(patient);
@@ -347,6 +378,10 @@ public class ExternalIDGrid extends PaginatedGrid<Patient, PatientFilter> {
 		}
 
 		setItems(filterList);
+	}
+
+	public void setEnabledDeleteSelectedPatientsButton(Boolean value) {
+		deleteAllSelectedPatientsButton.setEnabled(value);
 	}
 
 	public Collection<Patient> getDuplicatePatientsList() {


### PR DESCRIPTION
External Pseudonym tab : add delete all patients #213
Checkboxes added for each row in the table and a Delete Selected Patients at the top of the table that allows the user to choose multiple rows and delete them. A popup is shown before deletion for the user to confirm the action.
Before the table, button "Delete all patients" added. Empties all the values present in the table. A popup is shown before deletion for the user to confirm the action.
