### PR TITLE
Minor UI fixes

### DIFF
--- a/src/main/java/org/karnak/frontend/forwardnode/edit/component/ButtonSaveDeleteCancel.java
+++ b/src/main/java/org/karnak/frontend/forwardnode/edit/component/ButtonSaveDeleteCancel.java
@@ -39,16 +39,16 @@ public class ButtonSaveDeleteCancel extends HorizontalLayout {
 	}
 
 	private void setButtonSave() {
-		save.setWidth("33%");
+		save.getStyle().set("flex-grow", "1");
 		save.addThemeVariants(ButtonVariant.LUMO_PRIMARY);
 	}
 
 	private void setButtonCancel() {
-		cancel.setWidth("33%");
+		cancel.getStyle().set("flex-grow", "1");
 	}
 
 	private void setButtonDelete() {
-		delete.setWidth("33%");
+		delete.getStyle().set("flex-grow", "1");
 		delete.addThemeVariants(ButtonVariant.LUMO_ERROR, ButtonVariant.LUMO_PRIMARY);
 	}
 

--- a/src/main/java/org/karnak/frontend/forwardnode/edit/destination/component/TranscodeOnlyUncompressedComponent.java
+++ b/src/main/java/org/karnak/frontend/forwardnode/edit/destination/component/TranscodeOnlyUncompressedComponent.java
@@ -31,6 +31,9 @@ public class TranscodeOnlyUncompressedComponent extends VerticalLayout {
 
 		// Add components
 		addComponents();
+
+		// Align this component to the bottom of the container (aesthetical purpose)
+		getStyle().set("align-self", "flex-end");
 	}
 
 	/**
@@ -46,7 +49,7 @@ public class TranscodeOnlyUncompressedComponent extends VerticalLayout {
 	private void buildComponents() {
 		transcodeOnlyUncompressedCheckBox = new Checkbox("Transcode only uncompressed");
 		transcodeOnlyUncompressedCheckBox.getElement().getStyle().set("margin-left", "66px");
-		transcodeOnlyUncompressedCheckBox.getElement().getStyle().set("margin-top", "47px");
+		transcodeOnlyUncompressedCheckBox.getElement().getStyle().set("line-height", "31.5px");
 	}
 
 	public void init(Binder<DestinationEntity> binder) {

--- a/src/main/java/org/karnak/frontend/forwardnode/edit/destination/component/WarningNoProjectsDefined.java
+++ b/src/main/java/org/karnak/frontend/forwardnode/edit/destination/component/WarningNoProjectsDefined.java
@@ -51,11 +51,13 @@ public class WarningNoProjectsDefined extends Dialog {
 				"No projects are defined. You can't use the tag morphing or de-identification until you have created a project.");
 		divIntro.getStyle().set("padding-bottom", "10px");
 		divContent.add(divIntro);
-		btnValidate.setWidthFull();
-		btnCancel.setWidthFull();
+		btnValidate.setWidth("150px");
+		btnCancel.setWidth("150px");
 
-		HorizontalLayout btnLayout = new HorizontalLayout(btnValidate, btnCancel);
-		btnLayout.getStyle().set("margin-left", "50%");
+		HorizontalLayout btnLayout = new HorizontalLayout();
+		btnLayout.setWidthFull();
+		btnLayout.add(btnValidate, btnCancel);
+		btnValidate.getElement().getStyle().set("margin-left", "auto"); // https://vaadin.com/forum/thread/17198105/button-alignment-in-horizontal-layout
 		add(divTitle, divContent, btnLayout);
 	}
 

--- a/src/main/java/org/karnak/frontend/profile/ProfileLogic.java
+++ b/src/main/java/org/karnak/frontend/profile/ProfileLogic.java
@@ -145,6 +145,7 @@ public class ProfileLogic extends ListDataProvider<ProfileEntity> {
 		var warningIssuer = new Dialog();
 		var content = new Div();
 		var divTitle = new Div();
+		var btn = new Div();
 		divTitle.setText("Warning");
 		divTitle.getStyle()
 			.set("font-size", "large")
@@ -158,8 +159,10 @@ public class ProfileLogic extends ListDataProvider<ProfileEntity> {
 		var txt = new Text(
 				"The Issuer of Patient ID is no longer linked to a profile. Please fill in this field in the destination in the de-identification menu.");
 
-		content.add(divTitle, txt, okBtn);
-		warningIssuer.add(content);
+		btn.getStyle().set("text-align", "right");
+		btn.add(okBtn);
+		content.add(divTitle, txt);
+		warningIssuer.add(content, btn);
 		warningIssuer.setMaxWidth("30%");
 		warningIssuer.open();
 	}

--- a/src/main/java/org/karnak/frontend/profile/component/editprofile/ProfileMetadata.java
+++ b/src/main/java/org/karnak/frontend/profile/component/editprofile/ProfileMetadata.java
@@ -67,8 +67,11 @@ public class ProfileMetadata extends VerticalLayout {
 	}
 
 	private void setElements() {
-		titleDiv.getStyle().set("font-weight", "bold").set("margin-top", "0px").set("padding-left", "5px");
-		valueDiv.getStyle().set("color", "grey").set("padding-left", "10px").set("margin-top", "5px");
+		titleDiv.getStyle().set("font-weight", "bold").set("margin-top", "0px").set("padding-left", "5px").set("line-height", "31.5px").setHeight("38.5px");
+		valueDiv.getStyle().set("color", "grey").set("padding-left", "10px").set("line-height", "31.5px").setHeight("38.5px");
+		editButton.getStyle().set("margin-left", "10px");
+		validateEditButton.getStyle().set("margin-left", "5px");
+		disabledEditButton.getStyle().set("margin-left", "5px");
 	}
 
 	private void setTitleText() {
@@ -95,19 +98,19 @@ public class ProfileMetadata extends VerticalLayout {
 	}
 
 	private void editOnClick() {
-		titleDiv.remove(editButton);
+		editButton.getStyle().set("visibility", "hidden");
 		valueDiv.removeAll();
 		setValueTextField();
 	}
 
 	private void disabledEditButton() {
-		titleDiv.add(editButton);
+		editButton.getStyle().set("visibility", "visible");
 		valueDiv.removeAll();
 		setValueText();
 	}
 
 	private void validateEditButton() {
-		titleDiv.add(editButton);
+		editButton.getStyle().set("visibility", "visible");
 		value = valueField.getValue();
 		valueDiv.removeAll();
 		setValueText();

--- a/src/main/java/org/karnak/frontend/project/component/WarningRemoveProjectUsed.java
+++ b/src/main/java/org/karnak/frontend/project/component/WarningRemoveProjectUsed.java
@@ -20,7 +20,7 @@ public class WarningRemoveProjectUsed extends Dialog {
 	public void setText(ProjectEntity projectEntity) {
 		removeAll();
 		Div divTitle = new Div();
-		divTitle.setText(String.format("The project %s can't be remove", projectEntity.getName()));
+		divTitle.setText(String.format("The project %s can't be removed", projectEntity.getName()));
 		divTitle.getStyle()
 			.set("font-size", "large")
 			.set("font-weight", "bolder")


### PR DESCRIPTION
- Tab selection when navigating : When accessing a Karnak URL, the content is automatically rendered based on the path, the corresponding tab is now correctly selected. 
- Fixed buttons' position in warning and confirmation dialogs.
- Forward Node table : removed the horizontal scroll bar due to the save, delete and cancel buttons. Adapted their size to the parent's available space using the flex-grow property.
- Forward Node Destination form : aligned the transfer syntax select box with the checkbox next to it
- Profile details : added some space around edit, save and delete buttons, fixed the position of the text field when editing
- External Pseudonym table : added some space around the save and cancel buttons when editing a row in the table