### PR TITLE
New profile expression : computePatientAge

### DIFF
--- a/src/main/java/org/karnak/backend/model/expression/ExprAction.java
+++ b/src/main/java/org/karnak/backend/model/expression/ExprAction.java
@@ -16,6 +16,7 @@ import java.net.http.HttpResponse;
 import java.net.http.HttpResponse.BodyHandlers;
 import java.util.Objects;
 import org.dcm4che3.data.Attributes;
+import org.dcm4che3.data.Tag;
 import org.dcm4che3.data.VR;
 import org.dcm4che3.img.util.DicomUtils;
 import org.karnak.backend.exception.ExpressionActionException;
@@ -143,6 +144,12 @@ public class ExprAction implements ExpressionItem {
 
 	public boolean tagIsPresent(int tag) {
 		return DicomObjectTools.containsTagInAllAttributes(tag, dcmCopy);
+	}
+
+	public ActionItem ComputePatientAge() {
+		ActionItem replace = new Replace("D");
+		replace.setDummyValue(DicomUtils.getPatientAgeInPeriod(this.dcmCopy, Tag.PatientAge, false));
+		return replace;
 	}
 
 	/*

--- a/src/test/java/org/karnak/profilepipe/ProfileTest.java
+++ b/src/test/java/org/karnak/profilepipe/ProfileTest.java
@@ -613,7 +613,7 @@ class ProfileTest {
 	}
 
 	@Test
-	void expressionProfileComputePatientAge_keepExistingAge() {
+	void expressionProfileComputePatientAge_overwriteExistingAge() {
 		final Attributes dataset1 = new Attributes();
 
 		dataset1.setString(Tag.PatientName, VR.PN, "TEST-Expr-ComputePatientName");


### PR DESCRIPTION
Added a new custom function to be used in profile definitions that computes the age of the patient at the time of the acquisition and fills the value in the corresponding DICOM tag (0010,1010) before the data is potentially de-identified, and the birthdate deleted. The computation method comes from the weasis-dicom-tools dependency.
Profile Element example :

name: "Compute Patient Age"
codename: "expression.on.tags"
arguments:
expr: "ComputePatientAge()"
tags:
- "(0010,1010)"