### PR TITLE
Apply masks & clean pixel to any type of non compliant image

### DIFF
--- a/src/main/java/org/karnak/backend/service/profilepipe/Profile.java
+++ b/src/main/java/org/karnak/backend/service/profilepipe/Profile.java
@@ -197,12 +197,11 @@ public class Profile {
 			if (!StringUtil.hasText(sopClassUID)) {
 				throw new IllegalStateException("DICOM Object does not contain sopClassUID");
 			}
-			String scuPattern = sopClassUID + ".";
 			MaskArea mask = getMask(dcmCopy.getString(Tag.StationName));
 			// A mask must be applied with all the US and Secondary Capture sopClassUID,
 			// and with
 			// BurnedInAnnotation
-			if (isCleanPixelAllowedDependingImageType(dcmCopy, sopClassUID, scuPattern)
+			if (isCleanPixelAllowedDependingImageType(dcmCopy, sopClassUID)
 					&& evaluateConditionCleanPixelData(dcmCopy)) {
 				context.setMaskArea(mask);
 				if (mask == null) {
@@ -219,16 +218,16 @@ public class Profile {
 	 * Determine if the clean pixel should be applied depending on the image type
 	 * @param dcmCopy Attributes
 	 * @param sopClassUID SopClassUID
-	 * @param scuPattern Pattern
 	 * @return true if the clean pixel could be applied
 	 */
-	private boolean isCleanPixelAllowedDependingImageType(Attributes dcmCopy, String sopClassUID, String scuPattern) {
+    boolean isCleanPixelAllowedDependingImageType(Attributes dcmCopy, String sopClassUID) {
 		// A mask must be applied with all the US and Secondary Capture sopClassUID, and
-		// with
-		// BurnedInAnnotation
-		return scuPattern.startsWith("1.2.840.10008.5.1.4.1.1.6.")
-				|| scuPattern.startsWith("1.2.840.10008.5.1.4.1.1.7.")
-				|| scuPattern.startsWith("1.2.840.10008.5.1.4.1.1.3.")
+		// with BurnedInAnnotation
+		String sopPattern = sopClassUID + ".";
+
+		return sopPattern.startsWith("1.2.840.10008.5.1.4.1.1.6.")
+				|| sopPattern.startsWith("1.2.840.10008.5.1.4.1.1.7.")
+				|| sopPattern.startsWith("1.2.840.10008.5.1.4.1.1.3.")
 				|| sopClassUID.equals("1.2.840.10008.5.1.4.1.1.77.1.1")
 				|| "YES".equalsIgnoreCase(dcmCopy.getString(Tag.BurnedInAnnotation));
 	}


### PR DESCRIPTION
Some XA or RF images (or any kind) can contain patient information in the image depending on the station that produced the image
Clean pixel profile element application conditions
This profile is applied only on the following SOP:

1.2.840.10008.5.1.4.1.1.6.1 - Ultrasound Image Storage
1.2.840.10008.5.1.4.1.1.7.1 - Multiframe Single Bit Secondary Capture Image Storage
1.2.840.10008.5.1.4.1.1.7.2 - Multiframe Grayscale Byte Secondary Capture Image Storage
1.2.840.10008.5.1.4.1.1.7.3 - Multiframe Grayscale Word Secondary Capture Image Storage
1.2.840.10008.5.1.4.1.1.7.4 - Multiframe True Color Secondary Capture Image Storage
1.2.840.10008.5.1.4.1.1.3.1 - Ultrasound Multiframe Image Storage
1.2.840.10008.5.1.4.1.1.77.1.1 - VL endoscopic Image Storage
Or if the tag value Burned In Annotation (0028,0301) is “YES”

For the images outside this scope, a mask cannot be applied

Following the implementation of the new feature https://github.com/OsiriX-Foundation/karnak/issues/228 we can now define a profile that adds the BurnedInAnnotation attributes and sets its value properly

Example of profile:

name: "Clean pixel data"
version: "1.0"
minimumKarnakVersion: "0.9.2"
defaultIssuerOfPatientID:
profileElements:
- name: "Add tag BurnedInAnnotation if does not exist"
  codename: "action.add.tag"
  condition: "tagValueContains(#Tag.StationName, 'ICT256') && !tagIsPresent(#Tag.BurnedInAnnotation)"
  arguments:
    value: "YES"
    vr: "CS"
  tags:
    - "(0028,0301)"

- name: "Set BurnedInAnnotation to YES"
  codename: "expression.on.tags"
  condition: "tagValueContains(#Tag.StationName, 'ICT256')"
  arguments:
    expr: "Replace('YES')"
  tags:
    - "(0028,0301)"

- name: "Clean pixel data"
  codename: "clean.pixel.data"

- name: "DICOM basic profile"
  codename: "basic.dicom.profile"

masks:
  - ...