### PR TITLE
Clean Pixel Data: add conditions on the image size to masks definition and application

### DIFF
--- a/src/main/java/org/karnak/backend/data/entity/MaskEntity.java
+++ b/src/main/java/org/karnak/backend/data/entity/MaskEntity.java
@@ -11,21 +11,15 @@ package org.karnak.backend.data.entity;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import jakarta.persistence.Convert;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
-import java.awt.Rectangle;
+import jakarta.persistence.*;
+import org.karnak.backend.data.converter.RectangleListConverter;
+import org.karnak.backend.data.converter.RectangleListToStringListConverter;
+
+import java.awt.*;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
-import org.karnak.backend.data.converter.RectangleListConverter;
-import org.karnak.backend.data.converter.RectangleListToStringListConverter;
 
 @Entity(name = "Masks")
 @Table(name = "masks")
@@ -39,6 +33,10 @@ public class MaskEntity implements Serializable {
 
 	private String stationName;
 
+	private Long imageWidth;
+
+	private Long imageHeight;
+
 	private String color;
 
 	private List<Rectangle> rectangles = new ArrayList<>();
@@ -46,10 +44,16 @@ public class MaskEntity implements Serializable {
 	public MaskEntity() {
 	}
 
-	public MaskEntity(String stationName, String color, ProfileEntity profileEntity) {
+	public MaskEntity(String stationName, Long imageWidth, Long imageHeight, String color, ProfileEntity profileEntity) {
 		this.stationName = stationName;
 		this.color = color;
 		this.profileEntity = profileEntity;
+		this.imageHeight = imageHeight;
+		this.imageWidth = imageWidth;
+	}
+
+	public MaskEntity(String stationName, String color, ProfileEntity profileEntity) {
+		this(stationName, null, null, color, profileEntity);
 	}
 
 	public void addRectangle(String rectangle) {
@@ -103,6 +107,14 @@ public class MaskEntity implements Serializable {
 		this.stationName = stationName;
 	}
 
+	public Long getImageWidth() { return imageWidth; }
+
+	public void setImageWidth(Long imageWidth) { this.imageWidth = imageWidth; }
+
+	public Long getImageHeight() { return imageHeight; }
+
+	public void setImageHeight(Long imageHeight) { this.imageHeight = imageHeight; }
+
 	public String getColor() {
 		return color;
 	}
@@ -121,12 +133,13 @@ public class MaskEntity implements Serializable {
 		}
 		MaskEntity that = (MaskEntity) o;
 		return Objects.equals(id, that.id) && Objects.equals(stationName, that.stationName)
+				&& Objects.equals(imageWidth, that.imageWidth) && Objects.equals(imageHeight, that.imageHeight)
 				&& Objects.equals(color, that.color) && Objects.equals(rectangles, that.rectangles);
 	}
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(id, stationName, color, rectangles);
+		return Objects.hash(id, stationName, imageWidth, imageHeight, color, rectangles);
 	}
 
 }

--- a/src/main/java/org/karnak/backend/model/profilebody/MaskBody.java
+++ b/src/main/java/org/karnak/backend/model/profilebody/MaskBody.java
@@ -15,6 +15,10 @@ public class MaskBody {
 
 	private String stationName;
 
+	private Long imageWidth;
+
+	private Long imageHeight;
+
 	private String color;
 
 	private List<String> rectangles;
@@ -43,4 +47,19 @@ public class MaskBody {
 		this.rectangles = rectangles;
 	}
 
+	public Long getImageWidth() {
+		return imageWidth;
+	}
+
+	public void setImageWidth(Long imageWidth) {
+		this.imageWidth = imageWidth;
+	}
+
+	public Long getImageHeight() {
+		return imageHeight;
+	}
+
+	public void setImageHeight(Long imageHeight) {
+		this.imageHeight = imageHeight;
+	}
 }

--- a/src/main/java/org/karnak/backend/service/profilepipe/MaskStationCondition.java
+++ b/src/main/java/org/karnak/backend/service/profilepipe/MaskStationCondition.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2020-2021 Karnak Team and other contributors.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse
+ * Public License 2.0 which is available at https://www.eclipse.org/legal/epl-2.0, or the Apache
+ * License, Version 2.0 which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package org.karnak.backend.service.profilepipe;
+
+import java.util.Objects;
+
+public class MaskStationCondition {
+
+    private String stationName;
+
+    private Long imageWidth;
+
+    private Long imageHeight;
+
+    public MaskStationCondition(String stationName, Long imageWidth, Long imageHeight) {
+        this.stationName = stationName;
+        this.imageWidth = imageWidth;
+        this.imageHeight = imageHeight;
+    }
+
+    public MaskStationCondition(String stationName, String imageWidth, String imageHeight) {
+        this(stationName, imageWidth != null ? Long.valueOf(imageWidth) : null, imageHeight != null ? Long.valueOf(imageHeight) : null);
+    }
+
+    public MaskStationCondition(String stationName) {
+        this(stationName, (Long) null, null);
+    }
+
+    public String getStationName() {
+        return stationName;
+    }
+
+    public void setStationName(String stationName) {
+        this.stationName = stationName;
+    }
+
+    public Long getImageWidth() {
+        return imageWidth;
+    }
+
+    public void setImageWidth(Long imageWidth) {
+        this.imageWidth = imageWidth;
+    }
+
+    public Long getImageHeight() {
+        return imageHeight;
+    }
+
+    public void setImageHeight(Long imageHeight) {
+        this.imageHeight = imageHeight;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) return false;
+        MaskStationCondition that = (MaskStationCondition) o;
+        return Objects.equals(stationName, that.stationName) && Objects.equals(imageWidth, that.imageWidth) && Objects.equals(imageHeight, that.imageHeight);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(stationName, imageWidth, imageHeight);
+    }
+}

--- a/src/main/java/org/karnak/backend/service/profilepipe/Profile.java
+++ b/src/main/java/org/karnak/backend/service/profilepipe/Profile.java
@@ -9,34 +9,11 @@
  */
 package org.karnak.backend.service.profilepipe;
 
-import static org.karnak.backend.dicom.DefacingUtil.isAxial;
-import static org.karnak.backend.dicom.DefacingUtil.isCT;
-
-import java.awt.Color;
-import java.awt.Shape;
-import java.math.BigInteger;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
-import org.dcm4che3.data.Attributes;
-import org.dcm4che3.data.BulkData;
-import org.dcm4che3.data.Fragments;
-import org.dcm4che3.data.Sequence;
-import org.dcm4che3.data.Tag;
-import org.dcm4che3.data.VR;
+import org.dcm4che3.data.*;
 import org.dcm4che3.img.op.MaskArea;
 import org.dcm4che3.util.TagUtils;
-import org.karnak.backend.data.entity.DestinationEntity;
-import org.karnak.backend.data.entity.ProfileElementEntity;
-import org.karnak.backend.data.entity.ProfileEntity;
-import org.karnak.backend.data.entity.ProjectEntity;
-import org.karnak.backend.data.entity.SecretEntity;
+import org.karnak.backend.data.entity.*;
 import org.karnak.backend.dicom.Defacer;
 import org.karnak.backend.enums.ProfileItemType;
 import org.karnak.backend.model.action.ActionItem;
@@ -56,6 +33,15 @@ import org.slf4j.MarkerFactory;
 import org.weasis.core.util.StringUtil;
 import org.weasis.dicom.param.AttributeEditorContext;
 
+import java.awt.*;
+import java.math.BigInteger;
+import java.util.List;
+import java.util.*;
+import java.util.stream.Collectors;
+
+import static org.karnak.backend.dicom.DefacingUtil.isAxial;
+import static org.karnak.backend.dicom.DefacingUtil.isCT;
+
 @Slf4j
 public class Profile {
 
@@ -63,7 +49,7 @@ public class Profile {
 
 	private final Pseudonym pseudonym;
 
-	private final Map<String, MaskArea> maskMap;
+	private final Map<MaskStationCondition, MaskArea> maskMap;
 
 	public Profile(ProfileEntity profileEntity) {
 		this.maskMap = new HashMap<>();
@@ -71,20 +57,31 @@ public class Profile {
 		this.profiles = createProfilesList(profileEntity);
 	}
 
-	public void addMaskMap(Map<? extends String, ? extends MaskArea> maskMap) {
+	/*public void addMaskMap(Map<? extends String, ? extends MaskArea> maskMap) {
 		this.maskMap.putAll(maskMap);
-	}
+	}*/
 
-	public MaskArea getMask(String key) {
+	public MaskArea getMask(MaskStationCondition key) {
 		MaskArea mask = maskMap.get(key);
+		if (mask == null && (key.getImageWidth() != null || key.getImageHeight() != null)) {
+			// No exact match, remove image size information to match the station name only
+			key.setImageWidth(null);
+			key.setImageHeight(null);
+			mask = maskMap.get(key);
+		}
 		if (mask == null) {
-			mask = maskMap.get("*");
+			// No match with the station name, get the universal mask
+			mask = maskMap.get(new MaskStationCondition("*"));
 		}
 		return mask;
 	}
 
 	public void addMask(String stationName, MaskArea maskArea) {
-		this.maskMap.put(stationName, maskArea);
+		this.maskMap.put(new MaskStationCondition(stationName), maskArea);
+	}
+
+	public void addMask(MaskStationCondition key, MaskArea maskArea) {
+		this.maskMap.put(key, maskArea);
 	}
 
 	public static List<ProfileItem> getProfileItems(ProfileEntity profileEntity) {
@@ -122,7 +119,7 @@ public class Profile {
 					color = ActionTags.hexadecimal2Color(m.getColor());
 				}
 				List<Shape> shapeList = m.getRectangles().stream().map(Shape.class::cast).collect(Collectors.toList());
-				addMask(m.getStationName(), new MaskArea(shapeList, color));
+				addMask(new MaskStationCondition(m.getStationName(), m.getImageWidth(), m.getImageHeight()), new MaskArea(shapeList, color));
 			});
 			return profileItems;
 		}
@@ -198,7 +195,7 @@ public class Profile {
 				throw new IllegalStateException("DICOM Object does not contain sopClassUID");
 			}
 			String scuPattern = sopClassUID + ".";
-			MaskArea mask = getMask(dcmCopy.getString(Tag.StationName));
+			MaskArea mask = getMask(new MaskStationCondition(dcmCopy.getString(Tag.StationName), dcmCopy.getString(Tag.Columns), dcmCopy.getString(Tag.Rows)));
 			// A mask must be applied with all the US and Secondary Capture sopClassUID,
 			// and with
 			// BurnedInAnnotation

--- a/src/main/java/org/karnak/backend/service/profilepipe/Profile.java
+++ b/src/main/java/org/karnak/backend/service/profilepipe/Profile.java
@@ -63,7 +63,7 @@ public class Profile {
 
 	public MaskArea getMask(MaskStationCondition key) {
 		MaskArea mask = maskMap.get(key);
-		if (mask == null && (key.getImageWidth() != null || key.getImageHeight() != null)) {
+		if (mask == null) {
 			// No exact match, remove image size information to match the station name only
 			key.setImageWidth(null);
 			key.setImageHeight(null);

--- a/src/main/java/org/karnak/backend/service/profilepipe/ProfilePipeService.java
+++ b/src/main/java/org/karnak/backend/service/profilepipe/ProfilePipeService.java
@@ -9,21 +9,17 @@
  */
 package org.karnak.backend.service.profilepipe;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.concurrent.atomic.AtomicInteger;
-import org.karnak.backend.data.entity.ArgumentEntity;
-import org.karnak.backend.data.entity.ExcludedTagEntity;
-import org.karnak.backend.data.entity.IncludedTagEntity;
-import org.karnak.backend.data.entity.MaskEntity;
-import org.karnak.backend.data.entity.ProfileElementEntity;
-import org.karnak.backend.data.entity.ProfileEntity;
+import org.karnak.backend.data.entity.*;
 import org.karnak.backend.data.repo.ProfileRepo;
 import org.karnak.backend.enums.ProfileItemType;
 import org.karnak.backend.model.profilebody.ProfilePipeBody;
 import org.karnak.frontend.profile.component.errorprofile.ProfileError;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 
 @Service
 public class ProfilePipeService {
@@ -76,7 +72,7 @@ public class ProfilePipeService {
 				profilePipeYml.getMinimumKarnakVersion(), null, byDefault);
 		if (profilePipeYml.getMasks() != null) {
 			profilePipeYml.getMasks().forEach(m -> {
-				MaskEntity maskEntity = new MaskEntity(m.getStationName(), m.getColor(), newProfileEntity);
+				MaskEntity maskEntity = new MaskEntity(m.getStationName(), m.getImageWidth(), m.getImageHeight(), m.getColor(), newProfileEntity);
 				m.getRectangles().forEach(maskEntity::addRectangle);
 				newProfileEntity.addMask(maskEntity);
 			});

--- a/src/main/java/org/karnak/frontend/profile/component/editprofile/ProfileMasksView.java
+++ b/src/main/java/org/karnak/frontend/profile/component/editprofile/ProfileMasksView.java
@@ -12,10 +12,11 @@ package org.karnak.frontend.profile.component.editprofile;
 import com.vaadin.flow.component.Text;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
-import java.awt.Rectangle;
+import org.karnak.backend.data.entity.MaskEntity;
+
+import java.awt.*;
 import java.util.List;
 import java.util.Set;
-import org.karnak.backend.data.entity.MaskEntity;
 
 public class ProfileMasksView extends VerticalLayout {
 
@@ -34,6 +35,12 @@ public class ProfileMasksView extends VerticalLayout {
 			maskEntities.forEach(maskEntity -> {
 				if (maskEntity.getStationName() != null) {
 					add(setMasksValue("Station name : " + maskEntity.getStationName()));
+				}
+				if (maskEntity.getImageWidth() != null) {
+					add(setMasksValue("Image Width : " + maskEntity.getImageWidth()));
+				}
+				if (maskEntity.getImageHeight() != null) {
+					add(setMasksValue("Image Height : " + maskEntity.getImageHeight()));
 				}
 				if (maskEntity.getColor() != null) {
 					add(setMasksValue("Color : " + maskEntity.getColor()));

--- a/src/main/resources/db/changelog/changes/db.changelog-1.4.xml
+++ b/src/main/resources/db/changelog/changes/db.changelog-1.4.xml
@@ -32,4 +32,21 @@
     </dropColumn>
   </changeSet>
 
+  <changeSet author="karnak" id="1.4-3">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <columnExists tableName="masks" columnName="image_height"/>
+        <columnExists tableName="masks" columnName="image_width"/>
+      </not>
+    </preConditions>
+    <addColumn tableName="masks">
+      <column name="image_height" type="INTEGER">
+      </column>
+    </addColumn>
+    <addColumn tableName="masks">
+      <column name="image_width" type="INTEGER">
+      </column>
+    </addColumn>
+  </changeSet>
+
 </databaseChangeLog>


### PR DESCRIPTION
Define a similar condition as stationName to apply a mask when the stationName, imageHeight and imageWidth are corresponding to the instance being processed

Apply masks by decreasing order of match : if stationName, imageHeight and imageWidth are defined in the instance, look for a matching mask with all those parameters. If none is found, remove the size information and look for a match on the stationName. If none is found, return the universal mask corresponding to stationName = *