### PR TITLE
UI fixes: pseudonym mapping flex display and icons for DICOM tools

### DIFF
--- a/src/main/java/org/karnak/frontend/dicom/Util.java
+++ b/src/main/java/org/karnak/frontend/dicom/Util.java
@@ -485,14 +485,14 @@ public class Util {
 
 	private static String getWarningItem(boolean fontIcon) {
 		if (fontIcon) {
-			return "<iron-icon class=\"icon\" icon=\"icons:error\" style=\"width:1em; height:1em;\"></iron-icon>";
+			return "<vaadin-icon icon=\"vaadin:exclamation-circle\" style=\"width:1em; height:1em;\"></vaadin-icon>";
 		}
 		return "WARN";
 	}
 
 	private static String getOKItem(boolean fontIcon) {
 		if (fontIcon) {
-			return "<iron-icon class=\"icon\" icon=\"icons:check-circle\" style=\"width:1em; height:1em;\"></iron-icon>";
+			return "<vaadin-icon icon=\"vaadin:check-circle\" style=\"width:1em; height:1em;\"></vaadin-icon>";
 		}
 		return "OK";
 	}

--- a/src/main/java/org/karnak/frontend/dicom/echo/DicomEchoSelectionDialog.java
+++ b/src/main/java/org/karnak/frontend/dicom/echo/DicomEchoSelectionDialog.java
@@ -140,6 +140,7 @@ public class DicomEchoSelectionDialog extends AbstractDialog {
 
 	private void init() {
 		dialog = this.getContent();
+		dialog.setWidth("500px");
 
 		dicomNodeTypes = new ArrayList<>();
 		dicomNodes = new DicomNodeList("DicomNodes");

--- a/src/main/java/org/karnak/frontend/dicom/mwl/DicomWorkListSelectionDialog.java
+++ b/src/main/java/org/karnak/frontend/dicom/mwl/DicomWorkListSelectionDialog.java
@@ -101,6 +101,7 @@ public class DicomWorkListSelectionDialog extends AbstractDialog {
 
 	private void init() {
 		dialog = this.getContent();
+		dialog.setWidth("500px");
 
 		workListNodes = new DicomNodeList("Worklists");
 		buildDataProvider();

--- a/src/main/java/org/karnak/frontend/pseudonym/mapping/PseudonymMappingView.java
+++ b/src/main/java/org/karnak/frontend/pseudonym/mapping/PseudonymMappingView.java
@@ -16,16 +16,15 @@ import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
 import com.vaadin.flow.router.PageTitle;
 import com.vaadin.flow.router.Route;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 import org.karnak.backend.cache.Patient;
 import org.karnak.frontend.MainLayout;
 import org.karnak.frontend.pseudonym.mapping.component.MappingInputComponent;
 import org.karnak.frontend.pseudonym.mapping.component.MappingResultComponent;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.access.annotation.Secured;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
 
 @Route(value = PseudonymMappingView.ROUTE, layout = MainLayout.class)
 @PageTitle("KARNAK - Mapping Pseudonym")
@@ -178,15 +177,12 @@ public class PseudonymMappingView extends HorizontalLayout {
 
 		// Layout
 		mappingLayout = new VerticalLayout();
-		VerticalLayout inputLayout = new VerticalLayout();
 
 		// Titles
 		mappingLayout.add(new H2("Pseudonym Mapping"));
 
 		// Input
-		inputLayout.add(mappingInputComponent);
-		inputLayout.getElement().getStyle().set("margin-left", "22%");
-		mappingLayout.add(inputLayout);
+		mappingLayout.add(mappingInputComponent);
 
 		// Layout
 		add(mappingLayout);

--- a/src/main/java/org/karnak/frontend/pseudonym/mapping/component/MappingInputComponent.java
+++ b/src/main/java/org/karnak/frontend/pseudonym/mapping/component/MappingInputComponent.java
@@ -9,11 +9,11 @@
  */
 package org.karnak.frontend.pseudonym.mapping.component;
 
-import com.vaadin.flow.component.Unit;
 import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
 import com.vaadin.flow.component.textfield.TextField;
+import com.vaadin.flow.dom.Style;
 import org.karnak.frontend.component.BoxShadowComponent;
 
 /**
@@ -30,12 +30,12 @@ public class MappingInputComponent extends VerticalLayout {
 	 * Constructor
 	 */
 	public MappingInputComponent() {
-		setWidthFull();
 
 		// TextField input for pseudonym
 		pseudonymTextField = new TextField();
 		pseudonymTextField.setPlaceholder("Pseudonym to look for...");
-		pseudonymTextField.setMinWidth(85, Unit.PERCENTAGE);
+		pseudonymTextField.setWidth("30vw");
+		pseudonymTextField.setMinWidth("200px");
 
 		// Find Button
 		findButton = new Button("Find...");
@@ -43,10 +43,11 @@ public class MappingInputComponent extends VerticalLayout {
 
 		// Pseudonym layout
 		HorizontalLayout pseudonymLayout = new HorizontalLayout();
+		pseudonymLayout.getStyle().setJustifyContent(Style.JustifyContent.CENTER);
 		pseudonymLayout.add(pseudonymTextField, findButton);
 		BoxShadowComponent pseudonymBoxShadowComponent = new BoxShadowComponent(pseudonymLayout);
-		pseudonymBoxShadowComponent.getElement().getStyle().set("padding", "1%");
-		pseudonymBoxShadowComponent.getElement().getStyle().set("width", "44%");
+		pseudonymBoxShadowComponent.getElement().getStyle().set("padding", "10px");
+		pseudonymBoxShadowComponent.getElement().getStyle().set("margin", "auto");
 		add(pseudonymBoxShadowComponent);
 	}
 


### PR DESCRIPTION
UI fixes on 
- Pseudonym Mapping
Problem with the display of the view (horizontal scrollbar unnecessary), usage of flex box attributes to correct the display
- DICOM tools
In the connection results, there was icons generated using iron-icon that is probably a missing dependency. For aesthetics purposes, the icons are replaced with vaadin standard included icons and now are correctly displayed in the interface