### PR TITLE
Feat/expression excludeinstance

### DIFF
--- a/src/main/java/org/karnak/backend/model/action/ExcludeInstance.java
+++ b/src/main/java/org/karnak/backend/model/action/ExcludeInstance.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2020-2021 Karnak Team and other contributors.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse
+ * Public License 2.0 which is available at https://www.eclipse.org/legal/epl-2.0, or the Apache
+ * License, Version 2.0 which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package org.karnak.backend.model.action;
+
+import lombok.extern.slf4j.Slf4j;
+import org.dcm4che3.data.Attributes;
+import org.dcm4che3.util.TagUtils;
+import org.karnak.backend.model.profilepipe.HMAC;
+import org.slf4j.MDC;
+
+@Slf4j
+public class ExcludeInstance extends AbstractAction {
+
+	public ExcludeInstance(String symbol) {
+		super(symbol);
+	}
+
+	@Override
+	public void execute(Attributes dcm, int tag, HMAC hmac) {
+		if (log.isTraceEnabled()) {
+			String tagValueIn = AbstractAction.getStringValue(dcm, tag);
+			log.trace(CLINICAL_MARKER, PATTERN_WITH_IN, MDC.get("SOPInstanceUID"), TagUtils.toString(tag), symbol,
+					tagValueIn);
+		}
+	}
+
+}

--- a/src/main/java/org/karnak/backend/model/expression/ExprAction.java
+++ b/src/main/java/org/karnak/backend/model/expression/ExprAction.java
@@ -21,6 +21,7 @@ import org.dcm4che3.data.VR;
 import org.dcm4che3.img.util.DicomUtils;
 import org.karnak.backend.exception.ExpressionActionException;
 import org.karnak.backend.model.action.ActionItem;
+import org.karnak.backend.model.action.ExcludeInstance;
 import org.karnak.backend.model.action.Keep;
 import org.karnak.backend.model.action.Remove;
 import org.karnak.backend.model.action.Replace;
@@ -152,10 +153,14 @@ public class ExprAction implements ExpressionItem {
 		return replace;
 	}
 
+	public ActionItem ExcludeInstance() {
+		ActionItem exclude = new ExcludeInstance("E");
+		return exclude;
+	}
+
 	/*
 	 * public ActionItem Add(int newTag, VR newVr, String newValue){ Add add = new
 	 * Add("A", newTag, newVr, newValue); add.execute(dcm, newTag, null, null); return
 	 * null; }
 	 */
-
 }

--- a/src/test/java/org/karnak/backend/service/profilepipe/ProfileTest.java
+++ b/src/test/java/org/karnak/backend/service/profilepipe/ProfileTest.java
@@ -217,6 +217,7 @@ class ProfileTest {
 		assertEquals(new Rectangle(25, 75, 150, 50), ma3.getShapeList().getFirst());
 	}
 
+	@Test
 	void cleanPixelData_imageTypeIsXA_forceCleanPixelByStationNumber() {
 		// Use case : X Ray Angiography that contains identifying information
 		// but the BurnedInAnnotation attribute is not set


### PR DESCRIPTION
Define a new action to be used in an expression that excludes the current instance and does not transfer it
As soon as the instance is excluded, no other action is applied to it.
In the monitor view, the instance is shown as not sent, with the following message : Instance excluded by profile: profile element name

Example:

- name: "Exclude instance if SpecimenLabelInImage = YES"
codename: "expression.on.tags"
condition: "tagValueContains(#Tag.SpecimenLabelInImage, 'YES')"
tags
  - "(xxxx,xxxx)"
arguments:
  expr: "ExcludeInstance()"