### PR TITLE
new profile element add private tag and validation improvements on add action

### DIFF
--- a/src/main/java/org/karnak/backend/enums/ProfileItemType.java
+++ b/src/main/java/org/karnak/backend/enums/ProfileItemType.java
@@ -9,7 +9,17 @@
  */
 package org.karnak.backend.enums;
 
-import org.karnak.backend.model.profiles.*;
+import org.karnak.backend.model.profiles.ActionDates;
+import org.karnak.backend.model.profiles.ActionTags;
+import org.karnak.backend.model.profiles.AddPrivateTag;
+import org.karnak.backend.model.profiles.AddTag;
+import org.karnak.backend.model.profiles.BasicProfile;
+import org.karnak.backend.model.profiles.CleanPixelData;
+import org.karnak.backend.model.profiles.Defacing;
+import org.karnak.backend.model.profiles.Expression;
+import org.karnak.backend.model.profiles.PrivateTags;
+import org.karnak.backend.model.profiles.ProfileItem;
+import org.karnak.backend.model.profiles.UpdateUIDsProfile;
 
 public enum ProfileItemType {
 
@@ -23,7 +33,8 @@ public enum ProfileItemType {
 	ACTION_DATES(ActionDates.class, "action.on.dates", "113107",
 			"Retain Longitudinal Temporal Information Modified Dates Option"),
 	EXPRESSION_TAGS(Expression.class, "expression.on.tags", null, null),
-	ADD_TAG(AddTag.class, "action.add.tag", null, null);
+	ADD_TAG(AddTag.class, "action.add.tag", null, null),
+	ADD_PRIVATE_TAG(AddPrivateTag.class, "action.add.private.tag", null, null);
 
 	private final Class<? extends ProfileItem> profileClass;
 

--- a/src/main/java/org/karnak/backend/model/action/Add.java
+++ b/src/main/java/org/karnak/backend/model/action/Add.java
@@ -19,8 +19,15 @@ import org.slf4j.MDC;
 @Slf4j
 public class Add extends AbstractAction {
 
+	private String privateCreator;
+
 	public Add(String symbol, int newTag, VR vr, String dummyValue) {
 		super(symbol, newTag, vr, dummyValue);
+	}
+
+	public Add(String symbol, int newTag, VR vr, String dummyValue, String privateCreator) {
+		super(symbol, newTag, vr, dummyValue);
+		this.privateCreator = privateCreator;
 	}
 
 	@Override
@@ -35,10 +42,10 @@ public class Add extends AbstractAction {
 		if (dcm.contains(newTag)) return;
 
 		if (dummyValue != null) {
-			dcm.setString(newTag, vr, dummyValue);
+			dcm.setString(privateCreator, newTag, vr, dummyValue);
 		}
 		else {
-			dcm.setNull(newTag, vr);
+			dcm.setNull(privateCreator, newTag, vr);
 		}
 	}
 

--- a/src/test/java/org/karnak/backend/model/profiles/AddPrivateTagTest.java
+++ b/src/test/java/org/karnak/backend/model/profiles/AddPrivateTagTest.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2021 Karnak Team and other contributors.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse
+ * Public License 2.0 which is available at https://www.eclipse.org/legal/epl-2.0, or the Apache
+ * License, Version 2.0 which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package org.karnak.backend.model.profiles;
+
+import java.util.HashSet;
+import java.util.Set;
+import org.dcm4che3.data.Attributes;
+import org.dcm4che3.data.Tag;
+import org.dcm4che3.data.VR;
+import org.dcm4che3.util.TagUtils;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import org.junit.jupiter.api.Test;
+import org.karnak.backend.data.entity.ArgumentEntity;
+import org.karnak.backend.data.entity.IncludedTagEntity;
+import org.karnak.backend.data.entity.ProfileElementEntity;
+import org.karnak.backend.data.entity.ProfileEntity;
+import org.karnak.backend.model.standard.StandardDICOM;
+import org.karnak.backend.service.profilepipe.Profile;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+public class AddPrivateTagTest {
+
+    @Test
+    void addPrivateTag() {
+        ProfileEntity profileEntity = new ProfileEntity();
+        Attributes attributes = new Attributes();
+        attributes.setString(Tag.Modality, VR.CS, "XA");
+        attributes.setString(Tag.SOPClassUID, VR.UI, "1.2.840.10008.5.1.4.1.1.12.1");
+
+        Set<ProfileElementEntity> profileElementEntities = new HashSet<>();
+        ProfileElementEntity profileElementEntityAddBurnedAttr = new ProfileElementEntity();
+        profileElementEntityAddBurnedAttr.setCodename("action.add.private.tag");
+        profileElementEntityAddBurnedAttr.setName("Add private tag");
+        profileElementEntityAddBurnedAttr.addArgument(new ArgumentEntity("value", "PrivateValue", profileElementEntityAddBurnedAttr));
+        profileElementEntityAddBurnedAttr.addArgument(new ArgumentEntity("vr", "LO", profileElementEntityAddBurnedAttr));
+        profileElementEntityAddBurnedAttr.addArgument(new ArgumentEntity("privateCreator", "SIEMENS", profileElementEntityAddBurnedAttr));
+
+        profileElementEntityAddBurnedAttr.addIncludedTag(new IncludedTagEntity("(0021,1000)", profileElementEntityAddBurnedAttr));
+        profileElementEntityAddBurnedAttr.setPosition(1);
+
+        profileElementEntities.add(profileElementEntityAddBurnedAttr);
+        profileEntity.setProfileElementEntities(profileElementEntities);
+        Profile profile = new Profile(profileEntity);
+
+        profile.applyAction(attributes, attributes, null, null, null, null);
+
+        assertEquals("PrivateValue", attributes.getString(TagUtils.intFromHexString(StandardDICOM.cleanTagPath("(0021,1000)"))));
+        assertEquals("SIEMENS", attributes.getString(TagUtils.intFromHexString(StandardDICOM.cleanTagPath("(0021,0010)"))));
+    }
+
+   @Test
+    void addPrivateTagWithExistingPrivateCreator() {
+        ProfileEntity profileEntity = new ProfileEntity();
+        Attributes attributes = new Attributes();
+        attributes.setString(Tag.Modality, VR.CS, "XA");
+        attributes.setString(Tag.SOPClassUID, VR.UI, "1.2.840.10008.5.1.4.1.1.12.1");
+        attributes.setString(TagUtils.intFromHexString(StandardDICOM.cleanTagPath("(0021,0010)")), VR.LO, "SIEMENS");
+
+        Set<ProfileElementEntity> profileElementEntities = new HashSet<>();
+        ProfileElementEntity profileElementEntityAddBurnedAttr = new ProfileElementEntity();
+        profileElementEntityAddBurnedAttr.setCodename("action.add.private.tag");
+        profileElementEntityAddBurnedAttr.setName("Add private tag");
+       profileElementEntityAddBurnedAttr.addArgument(new ArgumentEntity("value", "PrivateValue", profileElementEntityAddBurnedAttr));
+       profileElementEntityAddBurnedAttr.addArgument(new ArgumentEntity("vr", "LO", profileElementEntityAddBurnedAttr));
+       profileElementEntityAddBurnedAttr.addIncludedTag(new IncludedTagEntity("(0021,1000)", profileElementEntityAddBurnedAttr));
+       profileElementEntityAddBurnedAttr.setPosition(1);
+
+       profileElementEntities.add(profileElementEntityAddBurnedAttr);
+       profileEntity.setProfileElementEntities(profileElementEntities);
+       Profile profile = new Profile(profileEntity);
+
+       profile.applyAction(attributes, attributes, null, null, null, null);
+
+       assertEquals("PrivateValue", attributes.getString(TagUtils.intFromHexString(StandardDICOM.cleanTagPath("(0021,1000)"))));
+    }
+
+   @Test
+   void addPrivateTagWithExistingPrivateCreator_specifyPrivateCreator() {
+       ProfileEntity profileEntity = new ProfileEntity();
+       Attributes attributes = new Attributes();
+       attributes.setString(Tag.Modality, VR.CS, "XA");
+       attributes.setString(Tag.SOPClassUID, VR.UI, "1.2.840.10008.5.1.4.1.1.12.1");
+       attributes.setString(TagUtils.intFromHexString(StandardDICOM.cleanTagPath("(0021,0010)")), VR.LO, "SIEMENS");
+
+       Set<ProfileElementEntity> profileElementEntities = new HashSet<>();
+       ProfileElementEntity profileElementEntityAddBurnedAttr = new ProfileElementEntity();
+       profileElementEntityAddBurnedAttr.setCodename("action.add.private.tag");
+       profileElementEntityAddBurnedAttr.setName("Add private tag");
+       profileElementEntityAddBurnedAttr.addArgument(new ArgumentEntity("value", "PrivateValue", profileElementEntityAddBurnedAttr));
+       profileElementEntityAddBurnedAttr.addArgument(new ArgumentEntity("vr", "LO", profileElementEntityAddBurnedAttr));
+       profileElementEntityAddBurnedAttr.addArgument(new ArgumentEntity("privateCreator", "SIEMENS", profileElementEntityAddBurnedAttr));
+       profileElementEntityAddBurnedAttr.addIncludedTag(new IncludedTagEntity("(0021,1000)", profileElementEntityAddBurnedAttr));
+       profileElementEntityAddBurnedAttr.setPosition(1);
+
+       profileElementEntities.add(profileElementEntityAddBurnedAttr);
+       profileEntity.setProfileElementEntities(profileElementEntities);
+       Profile profile = new Profile(profileEntity);
+
+       profile.applyAction(attributes, attributes, null, null, null, null);
+
+       assertEquals("PrivateValue", attributes.getString(TagUtils.intFromHexString(StandardDICOM.cleanTagPath("(0021,1000)"))));
+   }
+
+    @Test
+    void addPrivateTagWithExistingPrivateCreator_PrivateCreatorCollision() {
+        ProfileEntity profileEntity = new ProfileEntity();
+        Attributes attributes = new Attributes();
+        attributes.setString(Tag.Modality, VR.CS, "XA");
+        attributes.setString(Tag.SOPClassUID, VR.UI, "1.2.840.10008.5.1.4.1.1.12.1");
+        attributes.setString(TagUtils.intFromHexString(StandardDICOM.cleanTagPath("(0021,0010)")), VR.LO, "SIEMENS");
+
+        Set<ProfileElementEntity> profileElementEntities = new HashSet<>();
+        ProfileElementEntity profileElementEntityAddBurnedAttr = new ProfileElementEntity();
+        profileElementEntityAddBurnedAttr.setCodename("action.add.private.tag");
+        profileElementEntityAddBurnedAttr.setName("Add private tag");
+        profileElementEntityAddBurnedAttr.addArgument(new ArgumentEntity("value", "PrivateValue", profileElementEntityAddBurnedAttr));
+        profileElementEntityAddBurnedAttr.addArgument(new ArgumentEntity("vr", "LO", profileElementEntityAddBurnedAttr));
+        profileElementEntityAddBurnedAttr.addArgument(new ArgumentEntity("privateCreator", "PHILIPS", profileElementEntityAddBurnedAttr));
+        profileElementEntityAddBurnedAttr.addIncludedTag(new IncludedTagEntity("(0021,1000)", profileElementEntityAddBurnedAttr));
+        profileElementEntityAddBurnedAttr.setPosition(1);
+
+        profileElementEntities.add(profileElementEntityAddBurnedAttr);
+        profileEntity.setProfileElementEntities(profileElementEntities);
+        Profile profile = new Profile(profileEntity);
+
+        profile.applyAction(attributes, attributes, null, null, null, null);
+
+        assertNull(attributes.getString(TagUtils.intFromHexString(StandardDICOM.cleanTagPath("(0021,1000)"))));
+        assertEquals("SIEMENS", attributes.getString(TagUtils.intFromHexString(StandardDICOM.cleanTagPath("(0021,0010)"))));
+    }
+}


### PR DESCRIPTION
Add modification:
VR cannot be specified, it is retrieved from the DICOM Standard. Profile is validated against the attributes defined in the standard. If the tag is unknown, the profile cannot be created.
When applying the profile to a DICOM instance, Karnak checks if the attribute is defined in the instance's SOP, if not, the tag is not added to prevent data corruption, and a warning is logged.

Add private tag:
New profile element action.add.private.tag
Requires the same elements as the Add action, with a vr and privateCreator arguments.
PrivateCreator is not mandatory, it must exist in the instance and the tag will be linked to it.
If specified, it is either created if it does not exist, otherwise the existing value is matched against the argument, if equal, the tag is added, otherwise no action is applied and a warning is logged to enforce data coherence.