### PR TITLE
Adds a differentiation between error and excluded instances in monitoring and email notifications

### DIFF
--- a/src/main/java/org/karnak/backend/constant/Notification.java
+++ b/src/main/java/org/karnak/backend/constant/Notification.java
@@ -17,6 +17,8 @@ public class Notification {
 	// Default
 	public static final String DEFAULT_SUBJECT_ERROR_PREFIX = "**ERROR**";
 
+	public static final String DEFAULT_SUBJECT_REJECTION_PREFIX = "**REJECTED**";
+
 	public static final String DEFAULT_SUBJECT_PATTERN = "[Karnak Notification] %s %.30s";
 
 	public static final String DEFAULT_SUBJECT_VALUES = "PatientID,StudyDescription";

--- a/src/main/java/org/karnak/backend/data/entity/DestinationEntity.java
+++ b/src/main/java/org/karnak/backend/data/entity/DestinationEntity.java
@@ -29,6 +29,13 @@ import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
+import java.io.Serial;
+import java.io.Serializable;
+import java.time.LocalDateTime;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
 import org.hibernate.annotations.LazyCollection;
 import org.hibernate.annotations.LazyCollectionOption;
 import org.hibernate.validator.group.GroupSequenceProvider;
@@ -37,14 +44,6 @@ import org.karnak.backend.data.validator.DestinationGroupSequenceProvider.Destin
 import org.karnak.backend.data.validator.DestinationGroupSequenceProvider.DestinationStowGroup;
 import org.karnak.backend.enums.DestinationType;
 import org.karnak.backend.enums.PseudonymType;
-
-import java.io.Serial;
-import java.io.Serializable;
-import java.time.LocalDateTime;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Objects;
-import java.util.Set;
 
 @GroupSequenceProvider(value = DestinationGroupSequenceProvider.class)
 @Entity(name = "Destination")
@@ -102,6 +101,9 @@ public class DestinationEntity implements Serializable {
 
 	// Prefix of the email object when containing an issue. Default value: **ERROR**
 	private String notifyObjectErrorPrefix;
+
+	// Prefix of the email object when a rejection occurred. Default value: **REJECTED**
+	private String notifyObjectRejectionPrefix;
 
 	// Pattern of the email object, see
 	// https://dzone.com/articles/java-string-format-examples.
@@ -179,6 +181,7 @@ public class DestinationEntity implements Serializable {
 
 		this.notify = "";
 		this.notifyObjectErrorPrefix = "";
+		this.notifyObjectRejectionPrefix = "";
 		this.notifyObjectPattern = "";
 		this.notifyObjectValues = "";
 		this.notifyInterval = 0;
@@ -301,6 +304,14 @@ public class DestinationEntity implements Serializable {
 
 	public void setNotifyObjectErrorPrefix(String notifyObjectErrorPrefix) {
 		this.notifyObjectErrorPrefix = notifyObjectErrorPrefix;
+	}
+
+	public String getNotifyObjectRejectionPrefix() {
+		return notifyObjectRejectionPrefix;
+	}
+
+	public void setNotifyObjectRejectionPrefix(String notifyObjectRejectionPrefix) {
+		this.notifyObjectRejectionPrefix = notifyObjectRejectionPrefix;
 	}
 
 	public String getNotifyObjectPattern() {
@@ -553,6 +564,7 @@ public class DestinationEntity implements Serializable {
 		return contains(description, filterText) //
 				|| contains(notify, filterText) //
 				|| contains(notifyObjectErrorPrefix, filterText) //
+				|| contains(notifyObjectRejectionPrefix, filterText) //
 				|| contains(notifyObjectPattern, filterText) //
 				|| contains(notifyObjectValues, filterText) //
 				|| contains(aeTitle, filterText) //
@@ -576,20 +588,20 @@ public class DestinationEntity implements Serializable {
 			switch (destinationType) {
 				case dicom:
 					return "Destination [id=" + id + ", description=" + description + ", type=" + destinationType
-							+ ", notify=" + notify + ", notifyObjectErrorPrefix=" + notifyObjectErrorPrefix
+							+ ", notify=" + notify + ", notifyObjectErrorPrefix=" + notifyObjectErrorPrefix + ", notifyObjectRejectionPrefix=" + notifyObjectRejectionPrefix
 							+ ", notifyObjectPattern=" + notifyObjectPattern + ", notifyObjectValues="
 							+ notifyObjectValues + ", notifyInterval=" + notifyInterval + ", aeTitle=" + aeTitle
 							+ ", hostname=" + hostname + ", port=" + port + ", useaetdest=" + useaetdest + "]";
 				case stow:
 					return "Destination [id=" + id + ", description=" + description + ", type=" + destinationType
-							+ ", notify=" + notify + ", notifyObjectErrorPrefix=" + notifyObjectErrorPrefix
+							+ ", notify=" + notify + ", notifyObjectErrorPrefix=" + notifyObjectErrorPrefix + ", notifyObjectRejectionPrefix=" + notifyObjectRejectionPrefix
 							+ ", notifyObjectPattern=" + notifyObjectPattern + ", notifyObjectValues="
 							+ notifyObjectValues + ", notifyInterval=" + notifyInterval + ", url=" + url
 							+ ", headers=" + headers + "]";
 			}
 		}
 		return "Destination [id=" + id + ", description=" + description + ", type=" + destinationType + ", notify="
-				+ notify + ", notifyObjectErrorPrefix=" + notifyObjectErrorPrefix + ", notifyObjectPattern="
+				+ notify + ", notifyObjectErrorPrefix=" + notifyObjectErrorPrefix + ", notifyObjectRejectionPrefix=" + notifyObjectRejectionPrefix + ", notifyObjectPattern="
 				+ notifyObjectPattern + ", notifyObjectValues=" + notifyObjectValues + ", notifyInterval="
 				+ notifyInterval + "]";
 	}

--- a/src/main/java/org/karnak/backend/data/entity/TransferStatusEntity.java
+++ b/src/main/java/org/karnak/backend/data/entity/TransferStatusEntity.java
@@ -53,6 +53,8 @@ public class TransferStatusEntity implements Serializable {
 
 	private boolean sent;
 
+	private boolean error;
+
 	private String reason;
 
 	// Original
@@ -104,7 +106,7 @@ public class TransferStatusEntity implements Serializable {
 	public TransferStatusEntity() {
 	}
 
-	public TransferStatusEntity(Long forwardNodeId, Long destinationId, LocalDateTime transferDate, boolean sent,
+	public TransferStatusEntity(Long forwardNodeId, Long destinationId, LocalDateTime transferDate, boolean sent, boolean error,
 			String reason, String patientIdOriginal, String accessionNumberOriginal, String studyDescriptionOriginal,
 			LocalDateTime studyDateOriginal, String studyUidOriginal, String serieDescriptionOriginal,
 			LocalDateTime serieDateOriginal, String serieUidOriginal, String sopInstanceUidOriginal,
@@ -116,6 +118,7 @@ public class TransferStatusEntity implements Serializable {
 		this.destinationId = destinationId;
 		this.transferDate = transferDate;
 		this.sent = sent;
+		this.error = error;
 		this.reason = reason;
 		this.patientIdOriginal = patientIdOriginal;
 		this.accessionNumberOriginal = accessionNumberOriginal;
@@ -140,9 +143,9 @@ public class TransferStatusEntity implements Serializable {
 	}
 
 	public static TransferStatusEntity buildTransferStatusEntity(Long forwardNodeId, Long destinationId,
-			Attributes attributesOriginal, Attributes attributesToSend, boolean sent, String reason, String modality,
+			Attributes attributesOriginal, Attributes attributesToSend, boolean sent, boolean error, String reason, String modality,
 			String sopClassUid) {
-		return new TransferStatusEntity(forwardNodeId, destinationId, LocalDateTime.now(ZoneId.of("CET")), sent, reason,
+		return new TransferStatusEntity(forwardNodeId, destinationId, LocalDateTime.now(ZoneId.of("CET")), sent, error, reason,
 				attributesOriginal.getString(Tag.PatientID), attributesOriginal.getString(Tag.AccessionNumber),
 				attributesOriginal.getString(Tag.StudyDescription),
 				DateTimeUtils.dateTime(DateUtil.getDicomDate(attributesOriginal.getString(Tag.StudyDate)),
@@ -225,6 +228,14 @@ public class TransferStatusEntity implements Serializable {
 
 	public void setSent(boolean sent) {
 		this.sent = sent;
+	}
+
+	public boolean isError() {
+		return error;
+	}
+
+	public void setError(boolean error) {
+		this.error = error;
 	}
 
 	public String getReason() {

--- a/src/main/java/org/karnak/backend/data/repo/specification/TransferStatusSpecification.java
+++ b/src/main/java/org/karnak/backend/data/repo/specification/TransferStatusSpecification.java
@@ -65,6 +65,8 @@ public class TransferStatusSpecification implements Specification<TransferStatus
 		Path<String> pSopInstanceUidToSend = root.get("sopInstanceUidToSend");
 		// Status
 		Path<Boolean> pSent = root.get("sent");
+		// Error
+		Path<Boolean> pError = root.get("error");
 		// Transfer date
 		Path<LocalDateTime> pTransferDate = root.get("transferDate");
 
@@ -77,7 +79,7 @@ public class TransferStatusSpecification implements Specification<TransferStatus
 			// Sop Instance Uid
 			buildCriteriaSopInstanceUid(criteriaBuilder, predicates, pSopInstanceUidOriginal, pSopInstanceUidToSend);
 			// Sent
-			buildCriteriaSent(criteriaBuilder, predicates, pSent);
+			buildCriteriaSent(criteriaBuilder, predicates, pSent, pError);
 			// Transfer Date
 			buildCriteriaTransferDate(criteriaBuilder, predicates, pTransferDate);
 		}
@@ -142,10 +144,13 @@ public class TransferStatusSpecification implements Specification<TransferStatus
 	 * @param predicates Predicates to build
 	 * @param pSent Path of sent
 	 */
-	private void buildCriteriaSent(CriteriaBuilder criteriaBuilder, List<Predicate> predicates, Path<Boolean> pSent) {
+	private void buildCriteriaSent(CriteriaBuilder criteriaBuilder, List<Predicate> predicates, Path<Boolean> pSent, Path<Boolean> pError) {
 		if (transferStatusFilter.getTransferStatusType() != null
 				&& !Objects.equals(transferStatusFilter.getTransferStatusType(), TransferStatusType.ALL)) {
-			predicates.add(criteriaBuilder.equal(pSent, transferStatusFilter.getTransferStatusType().getCode()));
+			predicates.add(criteriaBuilder.equal(pSent, transferStatusFilter.getTransferStatusType().getSent()));
+			if (!Objects.equals(transferStatusFilter.getTransferStatusType(), TransferStatusType.NOT_SENT)) {
+				predicates.add(criteriaBuilder.equal(pError, transferStatusFilter.getTransferStatusType().getError()));
+			}
 		}
 	}
 

--- a/src/main/java/org/karnak/backend/enums/TransferStatusType.java
+++ b/src/main/java/org/karnak/backend/enums/TransferStatusType.java
@@ -14,34 +14,38 @@ package org.karnak.backend.enums;
  */
 public enum TransferStatusType {
 
-	ALL(null, "All"), SENT(true, "Sent"), NOT_SENT(false, "Not Sent");
+	ALL(null, null, "All"), SENT(true, false, "Sent"), NOT_SENT(false, null, "Not Sent"), EXCLUDED(false, false, "Excluded"), ERROR(false, true, "Error");
 
 	/**
-	 * Code of the enum
+	 * Predicate value for the sent attribute
 	 */
-	private final Boolean code;
+	private final Boolean sent;
 
 	/**
-	 * Description of the enum
+	 * Predicate value for the error attribute
 	 */
-	private final String description;
+	private final Boolean error;
 
 	/**
-	 * Constructor
-	 * @param code Code
-	 * @param description Description
+	 * Label of the filter value
 	 */
-	TransferStatusType(Boolean code, String description) {
-		this.code = code;
-		this.description = description;
+	private final String label;
+
+	TransferStatusType(Boolean sent, Boolean error, String label) {
+		this.label = label;
+		this.sent = sent;
+		this.error = error;
 	}
 
-	public Boolean getCode() {
-		return code;
+	public Boolean getSent() {
+		return sent;
 	}
 
-	public String getDescription() {
-		return description;
+	public Boolean getError() {
+		return error;
 	}
 
+	public String getLabel() {
+		return label;
+	}
 }

--- a/src/main/java/org/karnak/backend/model/notification/SerieSummaryNotification.java
+++ b/src/main/java/org/karnak/backend/model/notification/SerieSummaryNotification.java
@@ -29,6 +29,8 @@ public class SerieSummaryNotification {
 
 	private long nbTransferNotSent;
 
+	private boolean containsError;
+
 	private Set<String> unTransferedReasons;
 
 	private Set<String> transferredModalities;
@@ -73,6 +75,14 @@ public class SerieSummaryNotification {
 
 	public void setNbTransferNotSent(long nbTransferNotSent) {
 		this.nbTransferNotSent = nbTransferNotSent;
+	}
+
+	public boolean isContainsError() {
+		return containsError;
+	}
+
+	public void setContainsError(boolean containsError) {
+		this.containsError = containsError;
 	}
 
 	public Set<String> getUnTransferedReasons() {

--- a/src/main/java/org/karnak/backend/service/ForwardService.java
+++ b/src/main/java/org/karnak/backend/service/ForwardService.java
@@ -219,12 +219,12 @@ public class ForwardService {
 			launchCStore(p, streamSCU, dataWriter, cuid, iuid, syntax, transformedPlanarImage);
 
 			progressNotify(destination, p.getIuid(), p.getCuid(), false, streamSCU);
-			monitor(sourceNode.getId(), destination.getId(), attributesOriginal, attributesToSend, true, null,
+			monitor(sourceNode.getId(), destination.getId(), attributesOriginal, attributesToSend, true, false, null,
 					attributesOriginal.getString(Tag.Modality), p.getCuid());
 		}
 		catch (AbortException e) {
 			progressNotify(destination, p.getIuid(), p.getCuid(), true, streamSCU);
-			monitor(sourceNode.getId(), destination.getId(), attributesOriginal, attributesToSend, false,
+			monitor(sourceNode.getId(), destination.getId(), attributesOriginal, attributesToSend, false, false,
 					e.getMessage(), attributesOriginal.getString(Tag.Modality), p.getCuid());
 			if (e.getAbort() == Abort.CONNECTION_EXCEPTION) {
 				throw e;
@@ -232,7 +232,7 @@ public class ForwardService {
 		}
 		catch (IOException e) {
 			progressNotify(destination, p.getIuid(), p.getCuid(), true, streamSCU);
-			monitor(sourceNode.getId(), destination.getId(), attributesOriginal, attributesToSend, false,
+			monitor(sourceNode.getId(), destination.getId(), attributesOriginal, attributesToSend, false, true,
 					e.getMessage(), attributesOriginal.getString(Tag.Modality), p.getCuid());
 			throw e;
 		}
@@ -241,7 +241,7 @@ public class ForwardService {
 				Thread.currentThread().interrupt();
 			}
 			progressNotify(destination, p.getIuid(), p.getCuid(), true, streamSCU);
-			monitor(sourceNode.getId(), destination.getId(), attributesOriginal, attributesToSend, false,
+			monitor(sourceNode.getId(), destination.getId(), attributesOriginal, attributesToSend, false, true,
 					e.getMessage(), attributesOriginal.getString(Tag.Modality), p.getCuid());
 			log.error(ERROR_WHEN_FORWARDING, e);
 		}
@@ -369,12 +369,12 @@ public class ForwardService {
 			launchCStore(p, streamSCU, dataWriter, cuid, iuid, syntax, transformedPlanarImage);
 
 			progressNotify(destination, p.getIuid(), p.getCuid(), false, streamSCU);
-			monitor(fwdNode.getId(), destination.getId(), attributesOriginal, attributesToSend, true, null,
+			monitor(fwdNode.getId(), destination.getId(), attributesOriginal, attributesToSend, true, false, null,
 					attributesOriginal.getString(Tag.Modality), p.getCuid());
 		}
 		catch (AbortException e) {
 			progressNotify(destination, p.getIuid(), p.getCuid(), true, streamSCU);
-			monitor(fwdNode.getId(), destination.getId(), attributesOriginal, attributesToSend, false, e.getMessage(),
+			monitor(fwdNode.getId(), destination.getId(), attributesOriginal, attributesToSend, false, false, e.getMessage(),
 					attributesOriginal.getString(Tag.Modality), p.getCuid());
 			if (e.getAbort() == Abort.CONNECTION_EXCEPTION) {
 				throw e;
@@ -382,7 +382,7 @@ public class ForwardService {
 		}
 		catch (IOException e) {
 			progressNotify(destination, p.getIuid(), p.getCuid(), true, streamSCU);
-			monitor(fwdNode.getId(), destination.getId(), attributesOriginal, attributesToSend, false, e.getMessage(),
+			monitor(fwdNode.getId(), destination.getId(), attributesOriginal, attributesToSend, false, true, e.getMessage(),
 					attributesOriginal.getString(Tag.Modality), p.getCuid());
 			throw e;
 		}
@@ -391,7 +391,7 @@ public class ForwardService {
 				Thread.currentThread().interrupt();
 			}
 			progressNotify(destination, p.getIuid(), p.getCuid(), true, streamSCU);
-			monitor(fwdNode.getId(), destination.getId(), attributesOriginal, attributesToSend, false, e.getMessage(),
+			monitor(fwdNode.getId(), destination.getId(), attributesOriginal, attributesToSend, false, true, e.getMessage(),
 					attributesOriginal.getString(Tag.Modality), p.getCuid());
 			log.error(ERROR_WHEN_FORWARDING, e);
 		}
@@ -463,12 +463,12 @@ public class ForwardService {
 				}
 			}
 			progressNotify(destination, p.getIuid(), p.getCuid(), false, 0);
-			monitor(fwdNode.getId(), destination.getId(), attributesOriginal, attributesToSend, true, null,
+			monitor(fwdNode.getId(), destination.getId(), attributesOriginal, attributesToSend, true, false,null,
 					attributesOriginal.getString(Tag.Modality), p.getCuid());
 		}
 		catch (AbortException e) {
 			progressNotify(destination, p.getIuid(), p.getCuid(), true, 0);
-			monitor(fwdNode.getId(), destination.getId(), attributesOriginal, attributesToSend, false, e.getMessage(),
+			monitor(fwdNode.getId(), destination.getId(), attributesOriginal, attributesToSend, false, false, e.getMessage(),
 					attributesOriginal.getString(Tag.Modality), p.getCuid());
 			if (e.getAbort() == Abort.CONNECTION_EXCEPTION) {
 				throw e;
@@ -476,13 +476,13 @@ public class ForwardService {
 		}
 		catch (IOException e) {
 			progressNotify(destination, p.getIuid(), p.getCuid(), true, 0);
-			monitor(fwdNode.getId(), destination.getId(), attributesOriginal, attributesToSend, false, e.getMessage(),
+			monitor(fwdNode.getId(), destination.getId(), attributesOriginal, attributesToSend, false, true, e.getMessage(),
 					attributesOriginal.getString(Tag.Modality), p.getCuid());
 			throw e;
 		}
 		catch (Exception e) {
 			progressNotify(destination, p.getIuid(), p.getCuid(), true, 0);
-			monitor(fwdNode.getId(), destination.getId(), attributesOriginal, attributesToSend, false, e.getMessage(),
+			monitor(fwdNode.getId(), destination.getId(), attributesOriginal, attributesToSend, false, true, e.getMessage(),
 					attributesOriginal.getString(Tag.Modality), p.getCuid());
 			log.error(ERROR_WHEN_FORWARDING, e);
 		}
@@ -543,27 +543,27 @@ public class ForwardService {
 					uploadPayLoadFromTransformedImage(stow, syntax, context, attributes, desc);
 				}
 				progressNotify(destination, p.getIuid(), p.getCuid(), false, 0);
-				monitor(fwdNode.getId(), destination.getId(), attributesOriginal, attributesToSend, true, null,
+				monitor(fwdNode.getId(), destination.getId(), attributesOriginal, attributesToSend, true, false,null,
 						attributesOriginal.getString(Tag.Modality), p.getCuid());
 			}
 		}
 		catch (HttpException httpException) {
 			if (httpException.getStatusCode() != 409) {
 				progressNotify(destination, p.getIuid(), p.getCuid(), true, 0);
-				monitor(fwdNode.getId(), destination.getId(), attributesOriginal, attributesToSend, false,
+				monitor(fwdNode.getId(), destination.getId(), attributesOriginal, attributesToSend, false, true,
 						httpException.getMessage(), attributesOriginal.getString(Tag.Modality), p.getCuid());
 				throw new AbortException(Abort.FILE_EXCEPTION, "DICOMWeb forward", httpException);
 			}
 			else {
 				progressNotify(destination, p.getIuid(), p.getCuid(), false, 0);
-				monitor(fwdNode.getId(), destination.getId(), attributesOriginal, attributesToSend, true, null,
+				monitor(fwdNode.getId(), destination.getId(), attributesOriginal, attributesToSend, true, true, null,
 						attributesOriginal.getString(Tag.Modality), p.getCuid());
 				log.debug("File already present in destination");
 			}
 		}
 		catch (AbortException e) {
 			progressNotify(destination, p.getIuid(), p.getCuid(), true, 0);
-			monitor(fwdNode.getId(), destination.getId(), attributesOriginal, attributesToSend, false, e.getMessage(),
+			monitor(fwdNode.getId(), destination.getId(), attributesOriginal, attributesToSend, false, false, e.getMessage(),
 					attributesOriginal.getString(Tag.Modality), p.getCuid());
 			if (e.getAbort() == Abort.CONNECTION_EXCEPTION) {
 				throw e;
@@ -571,13 +571,13 @@ public class ForwardService {
 		}
 		catch (IOException e) {
 			progressNotify(destination, p.getIuid(), p.getCuid(), true, 0);
-			monitor(fwdNode.getId(), destination.getId(), attributesOriginal, attributesToSend, false, e.getMessage(),
+			monitor(fwdNode.getId(), destination.getId(), attributesOriginal, attributesToSend, false, true, e.getMessage(),
 					attributesOriginal.getString(Tag.Modality), p.getCuid());
 			throw e;
 		}
 		catch (Exception e) {
 			progressNotify(destination, p.getIuid(), p.getCuid(), true, 0);
-			monitor(fwdNode.getId(), destination.getId(), attributesOriginal, attributesToSend, false, e.getMessage(),
+			monitor(fwdNode.getId(), destination.getId(), attributesOriginal, attributesToSend, false, true, e.getMessage(),
 					attributesOriginal.getString(Tag.Modality), p.getCuid());
 			log.error(ERROR_WHEN_FORWARDING, e);
 		}
@@ -623,10 +623,10 @@ public class ForwardService {
 	 * @param sopClassUid Sop Class Uid
 	 */
 	private void monitor(Long forwardNodeId, Long destinationId, Attributes attributesOriginal,
-			Attributes attributesToSend, boolean sent, String reason, String modality, String sopClassUid) {
+			Attributes attributesToSend, boolean sent, boolean error, String reason, String modality, String sopClassUid) {
 		applicationEventPublisher
 			.publishEvent(new TransferMonitoringEvent(TransferStatusEntity.buildTransferStatusEntity(forwardNodeId,
-					destinationId, attributesOriginal, attributesToSend, sent, reason, modality, sopClassUid)));
+					destinationId, attributesOriginal, attributesToSend, sent, error, reason, modality, sopClassUid)));
 	}
 
 }

--- a/src/main/java/org/karnak/frontend/forwardnode/edit/destination/component/NotificationComponent.java
+++ b/src/main/java/org/karnak/frontend/forwardnode/edit/destination/component/NotificationComponent.java
@@ -33,6 +33,8 @@ public class NotificationComponent extends VerticalLayout {
 
 	private TextField notifyObjectErrorPrefix;
 
+	private TextField notifyObjectRejectionPrefix;
+
 	private TextField notifyObjectPattern;
 
 	private TextField notifyObjectValues;
@@ -42,6 +44,8 @@ public class NotificationComponent extends VerticalLayout {
 	private Checkbox activateNotification;
 
 	private Div notificationInputsDiv;
+
+	private Div notificationObjectsDiv;
 
 	/**
 	 * Constructor
@@ -67,11 +71,12 @@ public class NotificationComponent extends VerticalLayout {
 	 * Add components in notification components
 	 */
 	private void addComponents() {
-		notificationInputsDiv.add(UIS.setWidthFull(new HorizontalLayout(notify)),
-				UIS.setWidthFull(new HorizontalLayout(notifyObjectErrorPrefix, notifyObjectPattern, notifyObjectValues,
-						notifyInterval)));
+		//notificationObjectsDiv.add(UIS.setWidthFull(new HorizontalLayout(notify)), UIS.setWidthFull(new HorizontalLayout(notifyObjectErrorPrefix, notifyObjectRejectionPrefix)));
+		notificationInputsDiv.add(UIS.setWidthFull(new VerticalLayout(UIS.setWidthFull(new HorizontalLayout(notify)), UIS.setWidthFull(new HorizontalLayout(notifyObjectErrorPrefix, notifyObjectRejectionPrefix)),
+				UIS.setWidthFull(new HorizontalLayout(notifyObjectPattern, notifyObjectValues,
+						notifyInterval)))));
 
-		add(UIS.setWidthFull(new HorizontalLayout(activateNotification)), UIS.setWidthFull(notificationInputsDiv));
+		add(UIS.setWidthFull(new HorizontalLayout(activateNotification)), notificationInputsDiv);
 	}
 
 	/**
@@ -88,11 +93,13 @@ public class NotificationComponent extends VerticalLayout {
 		activateNotification.addValueChangeListener(event -> {
 			if (event != null && event.getValue()) {
 				notificationInputsDiv.setVisible(true);
+				notificationObjectsDiv.setVisible(true);
 				// Set default values if null or empty
 				updateDefaultValuesNotificationTextFields();
 			}
 			else {
 				notificationInputsDiv.setVisible(false);
+				notificationObjectsDiv.setVisible(false);
 			}
 		});
 	}
@@ -103,6 +110,9 @@ public class NotificationComponent extends VerticalLayout {
 	private void updateDefaultValuesNotificationTextFields() {
 		if (notifyObjectErrorPrefix.getValue() == null || notifyObjectErrorPrefix.getValue().trim().isEmpty()) {
 			notifyObjectErrorPrefix.setValue(Notification.DEFAULT_SUBJECT_ERROR_PREFIX);
+		}
+		if (notifyObjectRejectionPrefix.getValue() == null || notifyObjectRejectionPrefix.getValue().trim().isEmpty()) {
+			notifyObjectRejectionPrefix.setValue(Notification.DEFAULT_SUBJECT_REJECTION_PREFIX);
 		}
 		if (notifyObjectPattern.getValue() == null || notifyObjectPattern.getValue().trim().isEmpty()) {
 			notifyObjectPattern.setValue(Notification.DEFAULT_SUBJECT_PATTERN);
@@ -124,6 +134,10 @@ public class NotificationComponent extends VerticalLayout {
 				|| destinationEntity.getNotifyObjectErrorPrefix().trim().isEmpty()) {
 			destinationEntity.setNotifyObjectErrorPrefix(Notification.DEFAULT_SUBJECT_ERROR_PREFIX);
 		}
+		if (destinationEntity.getNotifyObjectRejectionPrefix() == null
+				|| destinationEntity.getNotifyObjectRejectionPrefix().trim().isEmpty()) {
+			destinationEntity.setNotifyObjectRejectionPrefix(Notification.DEFAULT_SUBJECT_REJECTION_PREFIX);
+		}
 		if (destinationEntity.getNotifyObjectPattern() == null
 				|| destinationEntity.getNotifyObjectPattern().trim().isEmpty()) {
 			destinationEntity.setNotifyObjectPattern(Notification.DEFAULT_SUBJECT_PATTERN);
@@ -142,9 +156,11 @@ public class NotificationComponent extends VerticalLayout {
 	 */
 	private void buildComponents() {
 		buildNotificationInputsDiv();
+		buildNotificationObjectsDiv();
 		buildActivateNotification();
 		buildNotify();
 		buildNotifyObjectErrorPrefix();
+		buildNotifyObjectRejectionPrefix();
 		buildNotifyObjectPattern();
 		buildNotifyObjectValues();
 		buildNotifyInterval();
@@ -155,7 +171,7 @@ public class NotificationComponent extends VerticalLayout {
 	 */
 	private void buildNotifyInterval() {
 		notifyInterval = new TextField(String.format("Notif.: interval (Default: %s)", Notification.DEFAULT_INTERVAL));
-		notifyInterval.setWidth("18%");
+		notifyInterval.setWidth("32%");
 		notifyInterval.addThemeVariants(TextFieldVariant.LUMO_ALIGN_RIGHT);
 		UIS.setTooltip(notifyInterval, String.format(
 				"Interval in seconds for sending a notification (when no new image is arrived in the archive folder). Default value: %s",
@@ -168,7 +184,7 @@ public class NotificationComponent extends VerticalLayout {
 	private void buildNotifyObjectValues() {
 		notifyObjectValues = new TextField(
 				String.format("Notif.: subject values (Default: %s)", Notification.DEFAULT_SUBJECT_VALUES));
-		notifyObjectValues.setWidth("24%");
+		notifyObjectValues.setWidth("32%");
 		UIS.setTooltip(notifyObjectValues, String.format(
 				"Values injected in the pattern [PatientID StudyDescription StudyDate StudyInstanceUID]. Default value: %s",
 				Notification.DEFAULT_SUBJECT_VALUES));
@@ -180,7 +196,7 @@ public class NotificationComponent extends VerticalLayout {
 	private void buildNotifyObjectPattern() {
 		notifyObjectPattern = new TextField(
 				String.format("Notif.: subject pattern (Default: %s)", Notification.DEFAULT_SUBJECT_PATTERN));
-		notifyObjectPattern.setWidth("24%");
+		notifyObjectPattern.setWidth("32%");
 		UIS.setTooltip(notifyObjectPattern, String.format(
 				"Pattern of the email object, see https://dzone.com/articles/java-string-format-examples. Default value: %s",
 				Notification.DEFAULT_SUBJECT_PATTERN));
@@ -192,10 +208,22 @@ public class NotificationComponent extends VerticalLayout {
 	private void buildNotifyObjectErrorPrefix() {
 		notifyObjectErrorPrefix = new TextField(
 				String.format("Notif.: error subject prefix (Default: %s)", Notification.DEFAULT_SUBJECT_ERROR_PREFIX));
-		notifyObjectErrorPrefix.setWidth("24%");
+		notifyObjectErrorPrefix.setWidth("49%");
 		UIS.setTooltip(notifyObjectErrorPrefix,
 				String.format("Prefix of the email object when containing an issue. Default value: %s",
 						Notification.DEFAULT_SUBJECT_ERROR_PREFIX));
+	}
+
+	/**
+	 * Notify Object Rejection Prefix
+	 */
+	private void buildNotifyObjectRejectionPrefix() {
+		notifyObjectRejectionPrefix = new TextField(
+				String.format("Notif.: rejection subject prefix (Default: %s)", Notification.DEFAULT_SUBJECT_REJECTION_PREFIX));
+		notifyObjectRejectionPrefix.setWidth("49%");
+		UIS.setTooltip(notifyObjectRejectionPrefix,
+				String.format("Prefix of the email object in case of rejections. Default value: %s",
+						Notification.DEFAULT_SUBJECT_REJECTION_PREFIX));
 	}
 
 	/**
@@ -224,6 +252,17 @@ public class NotificationComponent extends VerticalLayout {
 		notificationInputsDiv = new Div();
 		// By default hide
 		notificationInputsDiv.setVisible(false);
+		notificationInputsDiv.setWidthFull();
+	}
+
+	/**
+	 * Notification Inputs Div
+	 */
+	private void buildNotificationObjectsDiv() {
+		notificationObjectsDiv = new Div();
+		// By default hide
+		notificationObjectsDiv.setVisible(false);
+		notificationObjectsDiv.setWidthFull();
 	}
 
 	/**
@@ -253,6 +292,10 @@ public class NotificationComponent extends VerticalLayout {
 		binder.forField(getNotifyObjectErrorPrefix())
 			.bind(DestinationEntity::getNotifyObjectErrorPrefix, DestinationEntity::setNotifyObjectErrorPrefix);
 
+		// Error Prefix
+		binder.forField(getNotifyObjectRejectionPrefix())
+				.bind(DestinationEntity::getNotifyObjectRejectionPrefix, DestinationEntity::setNotifyObjectRejectionPrefix);
+
 		// Subject Pattern
 		binder.forField(getNotifyObjectPattern())
 			.bind(DestinationEntity::getNotifyObjectPattern, DestinationEntity::setNotifyObjectPattern);
@@ -276,6 +319,14 @@ public class NotificationComponent extends VerticalLayout {
 
 	public void setNotifyObjectErrorPrefix(TextField notifyObjectErrorPrefix) {
 		this.notifyObjectErrorPrefix = notifyObjectErrorPrefix;
+	}
+
+	public TextField getNotifyObjectRejectionPrefix() {
+		return notifyObjectRejectionPrefix;
+	}
+
+	public void setNotifyObjectRejectionPrefix(TextField notifyObjectRejectionPrefix) {
+		this.notifyObjectRejectionPrefix = notifyObjectRejectionPrefix;
 	}
 
 	public TextField getNotifyObjectPattern() {

--- a/src/main/java/org/karnak/frontend/monitoring/component/ExportSettingsDialog.java
+++ b/src/main/java/org/karnak/frontend/monitoring/component/ExportSettingsDialog.java
@@ -9,7 +9,6 @@
  */
 package org.karnak.frontend.monitoring.component;
 
-import com.vaadin.flow.component.Unit;
 import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.button.ButtonVariant;
 import com.vaadin.flow.component.dialog.Dialog;
@@ -49,8 +48,6 @@ public class ExportSettingsDialog extends Dialog {
 	 */
 	public ExportSettingsDialog() {
 		setModal(true);
-		setWidth(11, Unit.PERCENTAGE);
-		setHeight(37, Unit.PERCENTAGE);
 
 		// Build components
 		buildComponents();
@@ -120,8 +117,8 @@ public class ExportSettingsDialog extends Dialog {
 		// Textfields
 		delimiterTextField = new TextField("Delimiter");
 		quoteCharacterTextField = new TextField("Quote character");
-		delimiterTextField.setWidth(60, Unit.PERCENTAGE);
-		quoteCharacterTextField.setWidth(60, Unit.PERCENTAGE);
+		delimiterTextField.setWidthFull();
+		quoteCharacterTextField.setWidthFull();
 		VerticalLayout fieldsLayout = new VerticalLayout();
 		fieldsLayout.add(delimiterTextField, quoteCharacterTextField);
 

--- a/src/main/java/org/karnak/frontend/monitoring/component/TransferStatusGrid.java
+++ b/src/main/java/org/karnak/frontend/monitoring/component/TransferStatusGrid.java
@@ -326,7 +326,7 @@ public class TransferStatusGrid extends PaginatedGrid<TransferStatusEntity, Tran
 	 */
 	private void createHasBeenSentFilter(Column<TransferStatusEntity> statusColumn, HeaderRow filterRow) {
 		ComboBox<TransferStatusType> statusComboBox = new ComboBox<>();
-		statusComboBox.setItemLabelGenerator(TransferStatusType::getDescription);
+		statusComboBox.setItemLabelGenerator(TransferStatusType::getLabel);
 		statusComboBox.setPlaceholder("Filter Status");
 		statusComboBox.setItems(TransferStatusType.values());
 		statusComboBox.addValueChangeListener(event -> {
@@ -406,9 +406,18 @@ public class TransferStatusGrid extends PaginatedGrid<TransferStatusEntity, Tran
 	 */
 	private ComponentRenderer<Span, TransferStatusEntity> createColumnStatusComponentRenderer() {
 		return new ComponentRenderer<>(Span::new, (span, transferStatusEntity) -> {
+			StringBuilder pill = new StringBuilder();
+			pill.append("badge primary pill ");
+			if (transferStatusEntity.isSent()) {
+				pill.append("success");
+			} else if (transferStatusEntity.isError()) {
+				pill.append("error");
+			} else {
+				span.getStyle().setBackgroundColor("#d38900");
+			}
 			span.getElement()
 				.getThemeList()
-				.add(String.format("badge primary pill %s", transferStatusEntity.isSent() ? "success" : "error"));
+				.add(pill.toString());
 			span.setText(transferStatusEntity.isSent() ? "Sent" : transferStatusEntity.getReason());
 		});
 	}

--- a/src/main/resources/db/changelog/changes/db.changelog-1.4.xml
+++ b/src/main/resources/db/changelog/changes/db.changelog-1.4.xml
@@ -49,4 +49,33 @@
     </addColumn>
   </changeSet>
 
+  <changeSet author="karnak" id="1.4-4">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <columnExists tableName="transfer_status" columnName="error"/>
+      </not>
+    </preConditions>
+    <addColumn tableName="transfer_status">
+      <column name="error" type="BOOLEAN">
+      </column>
+    </addColumn>
+    <sql>
+        update transfer_status set error = true where sent = false;
+        update transfer_status set error = false where error is null;
+    </sql>
+  </changeSet>
+
+  <changeSet author="karnak" id="1.4-5">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <columnExists tableName="destination" columnName="notify_object_rejection_prefix"/>
+      </not>
+    </preConditions>
+    <addColumn tableName="destination">
+      <column name="notify_object_rejection_prefix" type="VARCHAR(255)"/>
+    </addColumn>
+    <sql>update destination set notify_object_rejection_prefix = '**REJECTED**' where notify_object_rejection_prefix is null;</sql>
+  </changeSet>
+
+
 </databaseChangeLog>

--- a/src/main/resources/templates/transferNotificationEmail.html
+++ b/src/main/resources/templates/transferNotificationEmail.html
@@ -64,11 +64,12 @@
                 <th>Sop class UID</th>
                 <th>Transferred</th>
                 <th>Not transferred</th>
+                <th>Contains error</th>
                 <th>Not transferred reasons</th>
               </tr>
               <tr th:each="serie, rowStat: ${notif.getSerieSummaryNotifications()}"
                   th:style="(${rowStat.odd} ? 'background: #f0f0f2;' : 'background: #ffffff;')+('text-align: center; vertical-align: middle;')"
-                  th:styleappend="${serie.getNbTransferNotSent()} > 0 ? 'color: red;' : 'color: black;'">
+                  th:styleappend="${serie.isContainsError()} ? 'color: red;' : (${serie.getNbTransferNotSent()} > 0 ? 'color: orange;' : 'color: black;')">
                 <td th:text="${serie.getSerieUid()}"/>
                 <td th:text="${serie.getSerieDescription()}"/>
                 <td th:text="${#temporals.format(serie.getSerieDate(), 'dd/MM/yyyy HH:mm:ss.SSS')}"/>
@@ -76,6 +77,7 @@
                 <td th:text="${serie.toStringTransferredSopClassUid()}"/>
                 <td th:text="${serie.getNbTransferSent()}"/>
                 <td th:text="${serie.getNbTransferNotSent()}"/>
+                <td th:text="${serie.isContainsError()} ? 'Yes' : 'No'"/>
                 <td th:text="${serie.toStringUnTransferredReasons}"/>
               </tr>
             </table>

--- a/src/test/java/org/karnak/backend/data/repo/specification/TransferStatusSpecificationTest.java
+++ b/src/test/java/org/karnak/backend/data/repo/specification/TransferStatusSpecificationTest.java
@@ -9,16 +9,15 @@
  */
 package org.karnak.backend.data.repo.specification;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.Arrays;
 import java.util.List;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.karnak.backend.data.entity.TransferStatusEntity;
@@ -186,7 +185,7 @@ class TransferStatusSpecificationTest {
 		assertNotNull(transferStatusEntities);
 		assertFalse(transferStatusEntities.isEmpty());
 		assertEquals(1, transferStatusEntities.size());
-		assertEquals(TransferStatusType.SENT.getCode(), transferStatusEntities.get(0).isSent());
+		assertEquals(TransferStatusType.SENT.getSent(), transferStatusEntities.get(0).isSent());
 	}
 
 	@Test


### PR DESCRIPTION
Today not sent instances are considered as errors even if the instance is specifically excluded using filters. It creates false positives in email notifications and monitoring view.
This development separates the errors that could unexpectedly occur and the expected instances that are excluded and not sent.