### PR TITLE
Make auth config password field hidden for display and available for edition

### DIFF
--- a/src/main/java/org/karnak/frontend/authconfig/component/AuthConfigComponent.java
+++ b/src/main/java/org/karnak/frontend/authconfig/component/AuthConfigComponent.java
@@ -63,12 +63,10 @@ public class AuthConfigComponent extends VerticalLayout {
         clientSecret = new PasswordField();
         clientSecret.setLabel("Client Secret");
         clientSecret.setWidthFull();
-        clientSecret.setRevealButtonVisible(false);
         layout.add(clientSecret);
         clientId = new PasswordField();
         clientId.setLabel("Client ID");
         clientId.setWidthFull();
-        clientId.setRevealButtonVisible(false);
         layout.add(clientId);
 
         add(layout);


### PR DESCRIPTION
It was possible to display the content of the password fields by clicking on the eye icon on the right when displaying the details of an authentication config element. This feature has been disabled to keep this information hidden. The possibility to display the content of the password field during creation is maintained for a better user experience