### PR TITLE
feat: Get roles from access token instead of id token

### DIFF
--- a/src/main/java/org/karnak/backend/config/SecurityConfiguration.java
+++ b/src/main/java/org/karnak/backend/config/SecurityConfiguration.java
@@ -10,8 +10,11 @@
 package org.karnak.backend.config;
 
 import com.vaadin.flow.spring.security.VaadinSecurityConfigurer;
+import java.util.Set;
+import lombok.extern.slf4j.Slf4j;
 import org.karnak.backend.security.OidcRoleAuthoritiesMapper;
 import org.karnak.backend.security.OpenIdConnectLogoutHandler;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.actuate.context.ShutdownEndpoint;
 import org.springframework.boot.actuate.info.InfoEndpoint;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -23,6 +26,15 @@ import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserRequest;
+import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
+import org.springframework.security.oauth2.core.OAuth2AccessToken;
+import org.springframework.security.oauth2.core.oidc.user.DefaultOidcUser;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.weasis.core.util.annotations.Generated;
 
@@ -30,11 +42,22 @@ import org.weasis.core.util.annotations.Generated;
 @Configuration
 @ConditionalOnProperty(value = "IDP", havingValue = "oidc")
 @Generated
+@Slf4j
 public class SecurityConfiguration {
 
 	// Spring Security default authorization request URL of the "keycloak" client
 	// registration (see application-oidc.yml)
 	private static final String OAUTH2_LOGIN_PAGE = "/oauth2/authorization/keycloak";
+
+	private final OidcRoleAuthoritiesMapper oidcRoleAuthoritiesMapper;
+
+	private final String jwkSetUri;
+
+	public SecurityConfiguration(OidcRoleAuthoritiesMapper oidcRoleAuthoritiesMapper,
+			@Value("${spring.security.oauth2.client.provider.keycloak.jwk-set-uri}") String jwkSetUri) {
+		this.oidcRoleAuthoritiesMapper = oidcRoleAuthoritiesMapper;
+		this.jwkSetUri = jwkSetUri;
+	}
 
 	@Bean
 	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -60,10 +83,13 @@ public class SecurityConfiguration {
 				.permitAll())
 			// OpenId connect login: map the IDP realm/client roles to the Karnak roles
 			// so that @RolesAllowed annotations on the views work with OIDC users. The
-			// login page points to the authorization URL so that unauthenticated users
-			// are sent directly to the IDP instead of the generated OAuth2 login page.
+			// roles are read from the Bearer/access token (not the ID token) via a
+			// custom OidcUserService, since GrantedAuthoritiesMapper only has access to
+			// the ID token/userinfo claims. The login page points to the authorization
+			// URL so that unauthenticated users are sent directly to the IDP instead of
+			// the generated OAuth2 login page.
 			.oauth2Login(oauth2 -> oauth2.loginPage(OAUTH2_LOGIN_PAGE)
-				.userInfoEndpoint(userInfo -> userInfo.userAuthoritiesMapper(new OidcRoleAuthoritiesMapper())))
+				.userInfoEndpoint(userInfo -> userInfo.oidcUserService(oidcUserService())))
 			// Vaadin/Spring Security integration: permits the framework internal
 			// requests and the @AnonymousAllowed views, scopes CSRF, configures the
 			// request cache, redirects unauthenticated users to the IDP and requires
@@ -82,6 +108,32 @@ public class SecurityConfiguration {
 		return web -> web.ignoring()
 			.requestMatchers("/VAADIN/**", "/img/**", "/sw.js", "/favicon.ico", "/manifest.webmanifest",
 					"/offline.html", "/sw-runtime-resources-precache.js");
+	}
+
+	/**
+	 * Decodes the raw Bearer/access token and maps the "karnak" client roles it carries
+	 * (via {@link OidcRoleAuthoritiesMapper}) onto the authenticated {@link OidcUser}, in
+	 * place of the roles Spring would otherwise derive from the ID token/userinfo.
+	 * @return OidcUserService
+	 */
+	private OAuth2UserService<OidcUserRequest, OidcUser> oidcUserService() {
+		final OidcUserService delegate = new OidcUserService();
+		return userRequest -> {
+			OidcUser oidcUser = delegate.loadUser(userRequest);
+			Jwt accessToken = decodeAccessToken(userRequest.getAccessToken());
+			Set<GrantedAuthority> authoritiesFromAccessToken = oidcRoleAuthoritiesMapper.mapAuthorities(accessToken);
+			return new DefaultOidcUser(authoritiesFromAccessToken, oidcUser.getIdToken(), oidcUser.getUserInfo());
+		};
+	}
+
+	/**
+	 * Decodes the raw Bearer/access token so its claims (in particular
+	 * "resource_access.karnak.roles") can be read.
+	 * @param accessToken the OAuth2 access token issued by the IDP
+	 * @return the decoded access token
+	 */
+	private Jwt decodeAccessToken(OAuth2AccessToken accessToken) {
+		return NimbusJwtDecoder.withJwkSetUri(jwkSetUri).build().decode(accessToken.getTokenValue());
 	}
 
 }

--- a/src/main/java/org/karnak/backend/security/OidcRoleAuthoritiesMapper.java
+++ b/src/main/java/org/karnak/backend/security/OidcRoleAuthoritiesMapper.java
@@ -11,32 +11,39 @@ package org.karnak.backend.security;
 
 import java.util.Collection;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.NonNull;
-import org.jspecify.annotations.Nullable;
 import org.karnak.backend.enums.SecurityRole;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
-import org.springframework.security.core.authority.mapping.GrantedAuthoritiesMapper;
-import org.springframework.security.oauth2.core.oidc.user.OidcUserAuthority;
-import org.springframework.security.oauth2.core.user.OAuth2UserAuthority;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.stereotype.Component;
 
 /**
- * Maps the roles provided by the OpenID Connect identity provider to the Karnak security
- * roles ({@link SecurityRole}).
+ * Maps the roles carried by the OpenID Connect provider's Bearer/access token to the
+ * Karnak security roles ({@link SecurityRole}).
  *
  * <p>
  * Roles are read exclusively from the Keycloak claim "resource_access.karnak.roles" of
- * the ID token and the userinfo endpoint. Only the roles matching a {@link SecurityRole}
- * type (admin, investigator, user) are mapped, as "ROLE_"-prefixed granted authorities.
- * The IDP must therefore be configured to include the roles of the "karnak" client in the
- * ID token or in the userinfo response (in Keycloak: client scope "roles").
+ * the decoded <b>access token (Bearer token)</b>, not from the ID token. Per OAuth2/OIDC
+ * semantics, the ID token authenticates the user to the client (its audience is the
+ * client id) while the access token is the credential presented to resource servers and
+ * is the standard place for authorization data. Its presence in the access token does
+ * not depend on an "Add to ID token" toggle in the IDP client scope configuration,
+ * unlike the ID token, whose content can legitimately vary between environments
+ * (e.g. present in a dev realm, absent in a cert realm) without this being a
+ * misconfiguration. Only the roles matching a {@link SecurityRole} type (admin,
+ * investigator, user) are mapped, as "ROLE_"-prefixed granted authorities. The IDP must
+ * therefore be configured to include the roles of the "karnak" client in the access
+ * token (in Keycloak: client scope "roles", mapper "Add to access token" enabled).
  */
-public class OidcRoleAuthoritiesMapper implements GrantedAuthoritiesMapper {
+@Component
+@Slf4j
+public class OidcRoleAuthoritiesMapper {
 
 	private static final String RESOURCE_ACCESS_CLAIM = "resource_access";
 
@@ -44,48 +51,62 @@ public class OidcRoleAuthoritiesMapper implements GrantedAuthoritiesMapper {
 
 	private static final String ROLES_CLAIM = "roles";
 
-	@Override
-	@NonNull public Collection<? extends GrantedAuthority> mapAuthorities(
-			@NonNull Collection<? extends GrantedAuthority> authorities) {
-		Set<GrantedAuthority> mappedAuthorities = new HashSet<>(authorities);
-		for (GrantedAuthority authority : authorities) {
-			if (authority instanceof OidcUserAuthority oidcUserAuthority) {
-				mappedAuthorities.addAll(extractRoles(oidcUserAuthority.getIdToken().getClaims()));
-				if (oidcUserAuthority.getUserInfo() != null) {
-					mappedAuthorities.addAll(extractRoles(oidcUserAuthority.getUserInfo().getClaims()));
-				}
-			}
-			else if (authority instanceof OAuth2UserAuthority oauth2UserAuthority) {
-				mappedAuthorities.addAll(extractRoles(oauth2UserAuthority.getAttributes()));
-			}
+	/**
+	 * Maps the roles of the "karnak" client found in the decoded access token to known
+	 * Karnak granted authorities.
+	 * @param accessToken the decoded Bearer/access token
+	 * @return the granted authorities matching a known {@link SecurityRole}
+	 */
+	@NonNull
+	public Set<GrantedAuthority> mapAuthorities(Jwt accessToken) {
+		Set<String> roleNames = extractRoleNames(accessToken.getClaims());
+		Set<GrantedAuthority> mappedAuthorities = roleNames.stream()
+			.map(SecurityRole::fromType)
+			.filter(Objects::nonNull)
+			.map(securityRole -> new SimpleGrantedAuthority(securityRole.getRole()))
+			.collect(Collectors.toCollection(HashSet::new));
+		Set<String> unknownRoleNames = roleNames.stream()
+			.filter(roleName -> SecurityRole.fromType(roleName) == null)
+			.collect(Collectors.toSet());
+		if (!unknownRoleNames.isEmpty()) {
+			log.warn(
+					"OIDC (access token): role(s) {} on the \"{}\" client do not match any known Karnak role "
+							+ "(expected one of: admin, investigator, user) and are ignored.",
+					unknownRoleNames, KARNAK_CLIENT);
 		}
 		return mappedAuthorities;
 	}
 
 	/**
-	 * Maps the roles of the "karnak" client found in the claims to known Karnak
-	 * authorities.
+	 * Returns the role names of the "karnak" entry of the "resource_access" claim of
+	 * the access token.
 	 */
-	private static Set<GrantedAuthority> extractRoles(Map<String, Object> claims) {
-		Set<String> roleNames = new HashSet<>();
-		if (claims.get(RESOURCE_ACCESS_CLAIM) instanceof Map<?, ?> resourceAccess) {
-			roleNames.addAll(retrieveRoles(resourceAccess.get(KARNAK_CLIENT)));
+	private static Set<String> extractRoleNames(Map<String, Object> claims) {
+		Object resourceAccessClaim = claims.get(RESOURCE_ACCESS_CLAIM);
+		if (!(resourceAccessClaim instanceof Map<?, ?> resourceAccess)) {
+			log.warn(
+					"OIDC (access token): no \"{}\" claim found. The IDP must include the client roles of the "
+							+ "\"{}\" client in the access token (Keycloak: client scope \"roles\", mapper "
+							+ "\"Add to access token\" enabled).",
+					RESOURCE_ACCESS_CLAIM, KARNAK_CLIENT);
+			return Set.of();
 		}
-		return roleNames.stream()
-			.map(SecurityRole::fromType)
-			.filter(Objects::nonNull)
-			.map(securityRole -> new SimpleGrantedAuthority(securityRole.getRole()))
-			.collect(Collectors.toSet());
-	}
-
-	/**
-	 * Returns the role names of the "karnak" entry of the "resource_access" claim.
-	 */
-	private static Collection<String> retrieveRoles(@Nullable Object accessClaim) {
-		if (accessClaim instanceof Map<?, ?> access && access.get(ROLES_CLAIM) instanceof Collection<?> roles) {
-			return roles.stream().filter(String.class::isInstance).map(String.class::cast).toList();
+		if (!resourceAccess.containsKey(KARNAK_CLIENT)) {
+			log.warn(
+					"OIDC (access token): no entry \"{}\" found in the \"{}\" claim (found clients: {}). Check "
+							+ "that the OIDC client id configured in Keycloak is exactly \"{}\".",
+					KARNAK_CLIENT, RESOURCE_ACCESS_CLAIM, resourceAccess.keySet(), KARNAK_CLIENT);
 		}
-		return List.of();
+		if (resourceAccess.get(KARNAK_CLIENT) instanceof Map<?, ?> resource
+				&& resource.get(ROLES_CLAIM) instanceof Collection<?> roles) {
+			return roles.stream()
+				.filter(String.class::isInstance)
+				.map(String.class::cast)
+				.collect(Collectors.toSet());
+		}
+		return Set.of();
 	}
 
 }
+
+

--- a/src/test/java/org/karnak/backend/security/OidcRoleAuthoritiesMapperTest.java
+++ b/src/test/java/org/karnak/backend/security/OidcRoleAuthoritiesMapperTest.java
@@ -12,18 +12,15 @@ package org.karnak.backend.security;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.util.Collection;
+import java.time.Instant;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
 import org.junit.jupiter.api.Test;
 import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
-import org.springframework.security.oauth2.core.oidc.OidcIdToken;
-import org.springframework.security.oauth2.core.oidc.OidcUserInfo;
-import org.springframework.security.oauth2.core.oidc.user.OidcUserAuthority;
-import org.springframework.security.oauth2.core.user.OAuth2UserAuthority;
+import org.springframework.security.oauth2.jwt.Jwt;
 
 @DisplayNameGeneration(ReplaceUnderscores.class)
 class OidcRoleAuthoritiesMapperTest {
@@ -31,129 +28,112 @@ class OidcRoleAuthoritiesMapperTest {
 	private final OidcRoleAuthoritiesMapper mapper = new OidcRoleAuthoritiesMapper();
 
 	@Test
-	void should_map_karnak_client_roles_of_id_token_to_karnak_roles() {
+	void should_map_karnak_client_roles_of_access_token_to_karnak_roles() {
 		// Init data
-		OidcIdToken idToken = OidcIdToken.withTokenValue("token")
-			.claim("sub", "user-id")
-			.claim("resource_access",
-					Map.of("karnak", Map.of("roles", List.of("admin", "investigator", "offline_access"))))
-			.build();
+		Jwt accessToken = jwtWithClaims(
+				Map.of("resource_access", Map.of("karnak", Map.of("roles", List.of("admin", "investigator", "offline_access")))));
 
 		// Call service
-		Collection<? extends GrantedAuthority> mapped = mapper.mapAuthorities(List.of(new OidcUserAuthority(idToken)));
+		Set<GrantedAuthority> mapped = mapper.mapAuthorities(accessToken);
 
 		// Test results
 		assertTrue(containsAuthority(mapped, "ROLE_admin"));
 		assertTrue(containsAuthority(mapped, "ROLE_investigator"));
 		// Roles unknown to Karnak are not mapped
-		assertEquals(3, mapped.size());
+		assertEquals(2, mapped.size());
 	}
 
 	@Test
-	void should_map_client_roles_of_user_info_to_karnak_roles() {
+	void when_no_resource_access_claim_should_return_no_authorities() {
 		// Init data
-		OidcIdToken idToken = OidcIdToken.withTokenValue("token").claim("sub", "user-id").build();
-		OidcUserInfo userInfo = OidcUserInfo.builder()
-			.subject("user-id")
-			.claim("resource_access", Map.of("karnak", Map.of("roles", List.of("user"))))
-			.build();
+		Jwt accessToken = jwtWithClaims(Map.of());
 
 		// Call service
-		Collection<? extends GrantedAuthority> mapped = mapper
-			.mapAuthorities(List.of(new OidcUserAuthority(idToken, userInfo)));
+		Set<GrantedAuthority> mapped = mapper.mapAuthorities(accessToken);
 
 		// Test results
-		assertTrue(containsAuthority(mapped, "ROLE_user"));
-	}
-
-	@Test
-	void should_map_roles_of_oauth2_user_attributes() {
-		// Init data
-		OAuth2UserAuthority authority = new OAuth2UserAuthority(
-				Map.of("resource_access", Map.of("karnak", Map.of("roles", List.of("admin")))));
-
-		// Call service
-		Collection<? extends GrantedAuthority> mapped = mapper.mapAuthorities(List.of(authority));
-
-		// Test results
-		assertTrue(containsAuthority(mapped, "ROLE_admin"));
-	}
-
-	@Test
-	void should_keep_original_authorities() {
-		// Init data
-		SimpleGrantedAuthority original = new SimpleGrantedAuthority("OIDC_USER");
-
-		// Call service
-		Collection<? extends GrantedAuthority> mapped = mapper.mapAuthorities(List.of(original));
-
-		// Test results
-		assertEquals(1, mapped.size());
-		assertTrue(containsAuthority(mapped, "OIDC_USER"));
+		assertTrue(mapped.isEmpty());
 	}
 
 	@Test
 	void when_no_role_claim_should_not_add_authorities() {
 		// Init data
-		OidcIdToken idToken = OidcIdToken.withTokenValue("token").claim("sub", "user-id").build();
+		Jwt accessToken = jwtWithClaims(Map.of("resource_access", Map.of()));
 
 		// Call service
-		Collection<? extends GrantedAuthority> mapped = mapper.mapAuthorities(List.of(new OidcUserAuthority(idToken)));
+		Set<GrantedAuthority> mapped = mapper.mapAuthorities(accessToken);
 
 		// Test results
-		assertEquals(1, mapped.size());
+		assertTrue(mapped.isEmpty());
 	}
 
 	@Test
 	void should_only_map_karnak_client_roles_ignoring_realm_and_other_clients() {
-		OidcIdToken idToken = OidcIdToken.withTokenValue("token")
-			.claim("sub", "user-id")
-			.claim("realm_access", Map.of("roles", List.of("admin")))
-			.claim("resource_access",
-					Map.of("karnak", Map.of("roles", List.of("user")), "other-client",
-							Map.of("roles", List.of("investigator"))))
-			.build();
+		// Init data
+		Jwt accessToken = jwtWithClaims(Map.of("realm_access", Map.of("roles", List.of("admin")), "resource_access",
+				Map.of("karnak", Map.of("roles", List.of("user")), "other-client",
+						Map.of("roles", List.of("investigator")))));
 
-		Collection<? extends GrantedAuthority> mapped = mapper.mapAuthorities(List.of(new OidcUserAuthority(idToken)));
+		// Call service
+		Set<GrantedAuthority> mapped = mapper.mapAuthorities(accessToken);
 
-		// Only the "karnak" client role is mapped (plus the original OIDC authority).
+		// Test results
 		assertTrue(containsAuthority(mapped, "ROLE_user"));
-		assertEquals(2, mapped.size());
-	}
-
-	@Test
-	void should_ignore_non_string_role_entries() {
-		OidcIdToken idToken = OidcIdToken.withTokenValue("token")
-			.claim("sub", "user-id")
-			.claim("resource_access", Map.of("karnak", Map.of("roles", List.of("admin", 42, true))))
-			.build();
-
-		Collection<? extends GrantedAuthority> mapped = mapper.mapAuthorities(List.of(new OidcUserAuthority(idToken)));
-
-		// Only the valid string role is mapped (plus the original OIDC authority).
-		assertTrue(containsAuthority(mapped, "ROLE_admin"));
-		assertEquals(2, mapped.size());
-	}
-
-	@Test
-	void should_ignore_a_malformed_resource_access_claim() {
-		OidcIdToken idToken = OidcIdToken.withTokenValue("token")
-			.claim("sub", "user-id")
-			.claim("resource_access", "not-a-map")
-			.build();
-
-		Collection<? extends GrantedAuthority> mapped = mapper.mapAuthorities(List.of(new OidcUserAuthority(idToken)));
-
 		assertEquals(1, mapped.size());
 	}
 
 	@Test
-	void should_return_an_empty_collection_for_no_authorities() {
-		assertTrue(mapper.mapAuthorities(List.of()).isEmpty());
+	void should_ignore_non_string_role_entries() {
+		// Init data
+		Jwt accessToken = jwtWithClaims(
+				Map.of("resource_access", Map.of("karnak", Map.of("roles", List.of("admin", 42, true)))));
+
+		// Call service
+		Set<GrantedAuthority> mapped = mapper.mapAuthorities(accessToken);
+
+		// Test results
+		assertTrue(containsAuthority(mapped, "ROLE_admin"));
+		assertEquals(1, mapped.size());
 	}
 
-	private static boolean containsAuthority(Collection<? extends GrantedAuthority> authorities, String authority) {
+	@Test
+	void should_ignore_a_malformed_resource_access_claim() {
+		// Init data
+		Jwt accessToken = jwtWithClaims(Map.of("resource_access", "not-a-map"));
+
+		// Call service
+		Set<GrantedAuthority> mapped = mapper.mapAuthorities(accessToken);
+
+		// Test results
+		assertTrue(mapped.isEmpty());
+	}
+
+	@Test
+	void should_ignore_a_malformed_karnak_client_entry() {
+		// Init data
+		Jwt accessToken = jwtWithClaims(Map.of("resource_access", Map.of("karnak", "not-a-map")));
+
+		// Call service
+		Set<GrantedAuthority> mapped = mapper.mapAuthorities(accessToken);
+
+		// Test results
+		assertTrue(mapped.isEmpty());
+	}
+
+	private static Jwt jwtWithClaims(Map<String, Object> claims) {
+		Jwt.Builder builder = Jwt.withTokenValue("token")
+			.header("alg", "none")
+			.subject("user-id")
+			.issuedAt(Instant.now())
+			.expiresAt(Instant.now().plusSeconds(60));
+		claims.forEach(builder::claim);
+		return builder.build();
+	}
+
+	private static boolean containsAuthority(Set<GrantedAuthority> authorities, String authority) {
 		return authorities.stream().anyMatch(ga -> ga.getAuthority().equals(authority));
 	}
 
 }
+
+


### PR DESCRIPTION
Roles are retrieved from bearer token type instead of id token type