### PR TITLE
test: fix stale sent() assertion for a 409-duplicate STOW-RS outcome

### DIFF
--- a/src/test/java/org/karnak/backend/service/ForwardServiceTest.java
+++ b/src/test/java/org/karnak/backend/service/ForwardServiceTest.java
@@ -204,10 +204,15 @@ class ForwardServiceTest {
 			.uploadDicom(any(Attributes.class), anyString());
 		WebForwardDestination dest = webDestination(stow, List.of());
 
-		// 409 means the object is already stored: success, no exception.
+		// 409 means the object is already stored: no exception propagates, and the
+		// outcome is monitored as a duplicate/retry (MonitoringWriteService.apply),
+		// not as a fresh send or an error.
 		forwardService.transferOther(fwdNode, dest, dataset(), params(null));
 
-		assertTrue(captureSingleEvent().sent());
+		MonitoringEntry event = captureSingleEvent();
+		assertTrue(event.duplicate());
+		assertFalse(event.sent());
+		assertFalse(event.error());
 	}
 
 	@Test


### PR DESCRIPTION
ForwardServiceTest.web_transfer_other_conflict_409_is_treated_as_already_present asserted MonitoringEntry.sent(), but MonitoringWriteService.apply() treats a 409 ("already present at destination") as a third, distinct outcome: it bumps series.retries via the duplicate flag and deliberately counts it in none of sent/errors/excluded (see the "neither sent, errored nor excluded" comment in MonitoringWriteService.apply()). The test predates that three-way outcome model and was never updated to match, so it fails deterministically today.

Assert duplicate() (and the negative sent()/error()) instead, matching the outcome ForwardService.transferOther() and MonitoringWriteService.apply() have deliberately implemented since the monitoring model was reworked to per-series aggregation.