### PR TITLE
fix: spaces in tags parsing

### DIFF
--- a/src/main/java/org/karnak/backend/model/profilepipe/TagActionMap.java
+++ b/src/main/java/org/karnak/backend/model/profilepipe/TagActionMap.java
@@ -19,7 +19,7 @@ import org.weasis.core.util.StringUtil;
 
 public class TagActionMap {
 
-	private static final Pattern TAG_SEPARATORS = Pattern.compile("[(),]");
+	private static final Pattern TAG_SEPARATORS = Pattern.compile("[(),\\s]");
 
 	/** A tag pattern resolved to its matching tag value and bit mask. */
 	private record PatternAction(int tag, int mask, ActionItem action) {
@@ -55,17 +55,17 @@ public class TagActionMap {
 		if (isValidPattern(cleanTag)) {
 			int patternTag = TagUtils.intFromHexString(cleanTag.replace("X", "0"));
 			int patternMask = TagUtils.intFromHexString(getMask(cleanTag));
-			tagPatternAction.put(cleanTag, new PatternAction(patternTag, patternMask, action));
+			this.tagPatternAction.put(cleanTag, new PatternAction(patternTag, patternMask, action));
 		}
 		else {
-			tagAction.put(TagUtils.intFromHexString(cleanTag), action);
+			this.tagAction.put(TagUtils.intFromHexString(cleanTag), action);
 		}
 	}
 
 	public @Nullable ActionItem get(Integer tag) {
-		ActionItem action = tagAction.get(tag);
+		ActionItem action = this.tagAction.get(tag);
 		if (action == null) {
-			for (PatternAction pattern : tagPatternAction.values()) {
+			for (PatternAction pattern : this.tagPatternAction.values()) {
 				if ((tag & pattern.mask()) == pattern.tag()) {
 					return pattern.action();
 				}

--- a/src/test/java/org/karnak/backend/model/profilepipe/TagActionMapTest.java
+++ b/src/test/java/org/karnak/backend/model/profilepipe/TagActionMapTest.java
@@ -9,12 +9,6 @@
  */
 package org.karnak.backend.model.profilepipe;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 import org.dcm4che3.data.Tag;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
@@ -22,6 +16,12 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.karnak.backend.model.action.Keep;
 import org.karnak.backend.model.action.Remove;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @DisplayNameGeneration(ReplaceUnderscores.class)
 class TagActionMapTest {
@@ -121,6 +121,36 @@ class TagActionMapTest {
 			map.put("0010XXXX", new Keep("K"));
 
 			assertNull(map.get(Tag.StudyDate));
+		}
+
+		@Test
+		void ignores_spaces_in_an_exact_tag() {
+			TagActionMap map = new TagActionMap();
+			Keep keep = new Keep("K");
+
+			map.put("(0010, 0010)", keep);
+
+			assertSame(keep, map.get(Tag.PatientName));
+		}
+
+		@Test
+		void ignores_surrounding_and_inner_spaces_in_an_exact_tag() {
+			TagActionMap map = new TagActionMap();
+			Keep keep = new Keep("K");
+
+			map.put("  ( 0010 , 0010)  ", keep);
+
+			assertSame(keep, map.get(Tag.PatientName));
+		}
+
+		@Test
+		void ignores_spaces_in_a_wildcard_pattern() {
+			TagActionMap map = new TagActionMap();
+			Remove remove = new Remove("X");
+
+			map.put("(0010, XXXX)", remove);
+
+			assertSame(remove, map.get(Tag.PatientName));
 		}
 
 	}


### PR DESCRIPTION
Make tag parsing whitespace-insensitive so tags like (0010, 1030) are handled the same as (0010,1030).